### PR TITLE
Support client settings

### DIFF
--- a/examples/client.json
+++ b/examples/client.json
@@ -1,0 +1,14 @@
+{
+    "engine1": {
+        "Threads": 2,
+        "Backend": "cudnn-auto",
+        "BackendOptions": "",
+        "NNCacheSize": 200000,
+        "MinibatchSize": 256,
+        "MaxPrefetch": 32
+    },
+    "engine2": {
+        "Threads": 4
+    },
+    "SyzygyPath": "path/to/tb/wdl"
+}

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -15,8 +15,9 @@ def cli():
 @click.option("--verbose", "-v", is_flag=True, default=False, help="Turn on debug output.")
 @click.option("--logfile", default=None, help="Path to where the log is saved to.")
 @click.option("--terminate-after", default=0, help="Terminate the client after x minutes.")
+@click.option("--clientconfig", default=None, help="Path to the client configuration file.")
 @click.argument("dbconfig")
-def run_client(verbose, logfile, terminate_after, dbconfig):
+def run_client(verbose, logfile, terminate_after, clientconfig, dbconfig):
     """ Run the client to generate games for distributed tuning.
 
     In order to connect to the database you need to provide a valid DBCONFIG
@@ -27,7 +28,7 @@ def run_client(verbose, logfile, terminate_after, dbconfig):
     logging.basicConfig(
         level=log_level, filename=logfile, format="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    tc = TuningClient(dbconfig_path=dbconfig, terminate_after=terminate_after)
+    tc = TuningClient(dbconfig_path=dbconfig, terminate_after=terminate_after, clientconfig=clientconfig)
     tc.run()
 
 

--- a/tune/io.py
+++ b/tune/io.py
@@ -1,11 +1,19 @@
 import re
+import sys
 from collections.abc import MutableMapping
 
 
 # TODO: Backup file to restore it, should there be an error
 def uci_tuple(uci_string):
-    name, value = re.findall(r"name (\w+) value (-?[0-9.]+)", uci_string)[0]
-    value = float(value)
+    try:
+        name, value = re.findall(r"name (\w+) value (-?[0-9.]+|\w*)", uci_string)[0]
+    except IndexError:
+        print(f"Error parsing UCI tuples:\n{uci_string}")
+        sys.exit(1)
+    try:
+        tmp = float(value)
+    except ValueError:
+        tmp = value
     return name, value
 
 

--- a/tune/io.py
+++ b/tune/io.py
@@ -14,7 +14,7 @@ def uci_tuple(uci_string):
         tmp = float(value)
     except ValueError:
         tmp = value
-    return name, value
+    return name, tmp
 
 
 def set_option(name, value):


### PR DESCRIPTION
Allow users to pass important client settings to the tuning client:

```
tune run-client --clientconfig client.json dbconfig.json
```

The config file could look like this:
```json
{
    "engine1": {
        "Threads": 2,
        "Backend": "cudnn",
        "BackendOptions": "",
        "NNCacheSize": 200000,
        "MinibatchSize": 512,
        "MaxPrefetch": 64
    },
    "engine2": {
        "Threads": 2
    },
    "SyzygyPath": "C:\\syzygy"
}
```

Fixes #13 