### PR TITLE
Support round flat priors for length scales

### DIFF
--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,10 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+from tune.priors import roundflat
+
+
+def test_roundflat():
+    assert_almost_equal(roundflat(0.3), 0.0, decimal=0.1)
+
+    assert roundflat(0.0) == -np.inf
+    assert roundflat(-1.0) == -np.inf

--- a/tune/priors.py
+++ b/tune/priors.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+__all__ = ["roundflat"]
+
+
+def roundflat(x, a_low=2.0, a_high=8.0, d_low=0.005, d_high=1.2):
+    """Return the log probability of the round flat prior.
+
+    The round flat prior is completely uninformative inside the interval bounds
+    ``d_low`` and ``d_high`` while smoothly going to -inf for values outside.
+    ``a_low`` and ``a_high`` specify how quickly the density falls at the boundaries.
+
+    Args:
+        x (float): A parameter value in [0, inf) for which to compute the log probability
+        a_low (float): Steepness of the prior at the boundary ``d_low``.
+        a_high (float): Steepness of the prior at the boundary ``d_high``.
+        d_low (float): Lower boundary for which the log probability is -2.
+        d_high (float): Upper boundary for which the log probability is -2.
+
+    Returns:
+        The log probability for x.
+    """
+    if x <= 0:
+        return -np.inf
+    return -2 * ((x / d_low) ** (-2 * a_low) + (x / d_high) ** (2 * a_high))


### PR DESCRIPTION
The inverse gamma distributions we currently use to constrain the length scales are well behaved and make the likelihood identified, but influence the posterior distribution too much.
The round flat prior also truncates the problematic part of the parameter space, while being almost flat inside the bounds.