### PR TITLE
Support reduction of the tuning ranges

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Unreleased version
+------------------
+* Add support for parameter range reduction. Since this potentially requires
+  discarding some of the data points, it will also save a backup.
+
 0.4 (2020-08-02)
 ----------------
 * Add new standalone tuning script. With this it is possible to tune parameters

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,5 +1,6 @@
 from numpy.testing import assert_almost_equal
-from tune.local import parse_experiment_result
+from tune.local import parse_experiment_result, reduce_ranges
+from skopt.utils import normalize_dimensions
 
 
 def test_parse_experiment_result():
@@ -16,3 +17,15 @@ def test_parse_experiment_result():
     score, error = parse_experiment_result(teststr, n_dirichlet_samples=1000)
     assert_almost_equal(score, 0.0)
     assert_almost_equal(error, 0.06, decimal=2)
+
+
+def test_reduce_ranges():
+    space = normalize_dimensions([(0.0, 1.0), ("a", "b", "c")])
+    x = ((0.0, "a"), (1.01, "a"), (0.5, "d"), (1.0, "c"))
+    y = (0.0, 1.0, 2.0, 3.0)
+    noise = (0.1, 0.2, 0.3, 0.4)
+    reduction_needed, x_new, y_new, noise_new = reduce_ranges(x, y, noise, space)
+    assert reduction_needed
+    assert tuple(x_new) == ((0.0, "a"), (1.0, "c"))
+    assert tuple(y_new) == (0.0, 3.0)
+    assert tuple(noise_new) == (0.1, 0.4)


### PR DESCRIPTION
This pull request will make it possible to reduce the ranges of the parameters during a run. This is useful when it turns out that the optimum is close to a boundary or small in general and one needs to "zoom in" a bit.
Since there is no good way to incorporate the existing points falling outside the new ranges, these have to be discarded. The new code will save a backup just in case the user wants to go back at a later stage.

The range reduction might produce some surprising results, since the landscape might shift quite a bit due to the missing leverage of the discarded points. The tune needs some amount of iterations to stabilize again. Therefore one should only rarely use this feature.

Closes #37 