### PR TITLE
Print confidence interval when reporting the current optimum

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.5.0-beta.2 (2020-08-10)
+-------------------------
+* Add support for confidence intervals of the optimum. By default a table of
+  highest density intervals will be reported alongside the current optimum.
+
 0.5.0-beta (2020-08-03)
 -----------------------
 * Add support for parameter range reduction. Since this potentially requires

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,6 +16,26 @@ version = "1.4.4"
 
 [[package]]
 category = "main"
+description = "Exploratory analysis of Bayesian models"
+name = "arviz"
+optional = false
+python-versions = "*"
+version = "0.9.0"
+
+[package.dependencies]
+matplotlib = ">=3.0"
+netcdf4 = "*"
+numpy = ">=1.12"
+packaging = "*"
+pandas = ">=0.23"
+scipy = ">=0.19"
+xarray = ">=0.11"
+
+[package.extras]
+all = ["numba", "bokeh (>=1.4.0)"]
+
+[[package]]
+category = "main"
 description = "Atomic file writes."
 name = "atomicwrites"
 optional = false
@@ -52,18 +72,22 @@ category = "main"
 description = "A fully Bayesian implementation of sequential model-based optimization"
 name = "bask"
 optional = false
-python-versions = ">=3.7"
-version = "0.7.2"
+python-versions = ">=3.7,<4.0"
+version = "0.8.0"
 
 [package.dependencies]
-Click = ">=7.0"
-emcee = ">=3.0"
-matplotlib = "*"
-numpy = "*"
-scikit-learn = ">=0.18.2,<0.23"
-scikit-optimize = "*"
-scipy = "*"
-tqdm = "*"
+Click = ">=7.1.2,<8.0.0"
+arviz = ">=0.9.0,<0.10.0"
+emcee = ">=3.0.2,<4.0.0"
+matplotlib = ">=3.3.0,<4.0.0"
+numpy = ">=1.19.1,<2.0.0"
+scikit-learn = ">=0.22,<0.23"
+scikit-optimize = ">=0.7.4,<0.8.0"
+scipy = ">=1.5.2,<2.0.0"
+tqdm = ">=4.48.2,<5.0.0"
+
+[package.extras]
+docs = ["Sphinx (>=3.1.2,<4.0.0)", "numpydoc (>=1.1.0,<2.0.0)", "nbsphinx (>=0.7.1,<0.8.0)", "nbsphinx-link (>=1.3.0,<2.0.0)"]
 
 [[package]]
 category = "dev"
@@ -108,6 +132,17 @@ name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
 version = "3.2.0"
+
+[[package]]
+category = "main"
+description = "Time-handling functionality from netcdf4-python"
+name = "cftime"
+optional = false
+python-versions = "*"
+version = "1.2.1"
+
+[package.dependencies]
+numpy = "*"
 
 [[package]]
 category = "main"
@@ -332,6 +367,18 @@ python-versions = ">=3.5"
 version = "8.4.0"
 
 [[package]]
+category = "main"
+description = "Provides an object-oriented python interface to the netCDF version 4 library."
+name = "netcdf4"
+optional = false
+python-versions = "*"
+version = "1.5.4"
+
+[package.dependencies]
+cftime = "*"
+numpy = ">=1.9"
+
+[[package]]
 category = "dev"
 description = "Node.js virtual environment builder"
 name = "nodeenv"
@@ -363,7 +410,7 @@ six = "*"
 category = "main"
 description = "Powerful data structures for data analysis, time series, and statistics"
 name = "pandas"
-optional = true
+optional = false
 python-versions = ">=3.6.1"
 version = "1.1.0"
 
@@ -850,6 +897,19 @@ version = "0.34.2"
 test = ["pytest (>=3.0.0)", "pytest-cov"]
 
 [[package]]
+category = "main"
+description = "N-D labeled arrays and datasets in Python"
+name = "xarray"
+optional = false
+python-versions = ">=3.6"
+version = "0.16.0"
+
+[package.dependencies]
+numpy = ">=1.15"
+pandas = ">=0.25"
+setuptools = ">=41.2"
+
+[[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
@@ -867,7 +927,7 @@ dist = ["joblib", "psycopg2", "sqlalchemy", "pandas"]
 docs = ["Sphinx"]
 
 [metadata]
-content-hash = "95ef5627e8cf34834b746d5308dbcc343c5ca5b38e2d8941acbf3f8c51c9f82e"
+content-hash = "f57aac37ec41fd8de119574361f300b53e4769792c4028b6acd959097e52aad3"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -879,6 +939,10 @@ alabaster = [
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+arviz = [
+    {file = "arviz-0.9.0-py3-none-any.whl", hash = "sha256:18c907090de4c0ddfbcf2c46f60888d7238bc3d5fe4378f70d5f765636cb5f85"},
+    {file = "arviz-0.9.0.tar.gz", hash = "sha256:85473435c29d54b50ee5a9e3d5ab30764f06dbaf0bcfdae222ea58715338a85f"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -893,8 +957,8 @@ babel = [
     {file = "Babel-2.8.0.tar.gz", hash = "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38"},
 ]
 bask = [
-    {file = "bask-0.7.2-py2.py3-none-any.whl", hash = "sha256:080cb8bd6effed406d7a3d0fac7949149d2aa10524be80786394ca7df764ca2c"},
-    {file = "bask-0.7.2.tar.gz", hash = "sha256:7fea4194d70e98fe9b75157d74a29d943c16d5666f4282a7f0047bf7e46440aa"},
+    {file = "bask-0.8.0-py3-none-any.whl", hash = "sha256:362cf410ca3412e70c70ad2e7d0687aa179fe41345c6cfaa3d58833f7ed09ac4"},
+    {file = "bask-0.8.0.tar.gz", hash = "sha256:d022af687f610060dcb37e8c3181bccf82f673ed2ead45d057997346f682bbe4"},
 ]
 black = [
     {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
@@ -911,6 +975,24 @@ certifi = [
 cfgv = [
     {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
     {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
+]
+cftime = [
+    {file = "cftime-1.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1381b4ba9e53e932472a7da574d8553477d15aa8bc647425cb0110db4f4dfdac"},
+    {file = "cftime-1.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5ddbc9514719e6b964cd9fd5f306679af09f53f8f6792888d62448b1b6d764d9"},
+    {file = "cftime-1.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7a2b0a3821071560d2ae01236215be6dd7bfa81328823ec602f37496aeea35d0"},
+    {file = "cftime-1.2.1-cp36-none-win32.whl", hash = "sha256:33b5180650a4aace7ce021af4af0f278477be94276da7b7c8ae51b49e5a022a9"},
+    {file = "cftime-1.2.1-cp36-none-win_amd64.whl", hash = "sha256:eba48c7e47468f16cb1c8caf6ce772e39d067100e3893b94cf7dd394ec23d943"},
+    {file = "cftime-1.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3c23e4b0109ff7b878fc60d7ed9131bdc8c2c8ea098c2f9200e19c596ffe0019"},
+    {file = "cftime-1.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:7cb8defe607da8cacbd4ebb3b983571732b0476be98decda37595ae49108797f"},
+    {file = "cftime-1.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fec04d3bed7078f1a62db7dab12790b96eb3b48e3522ad0c28c9d36175b99f89"},
+    {file = "cftime-1.2.1-cp37-none-win32.whl", hash = "sha256:d6bf1c1954660a500d11ca047151205182212dfaa20b2eb0c6dfe372140868fc"},
+    {file = "cftime-1.2.1-cp37-none-win_amd64.whl", hash = "sha256:08bc1af49f92a31b8b58a4d8b61bf457e17832eb3440eac7eec79afca7d0be59"},
+    {file = "cftime-1.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf797e0c71631406a19fe2a69ff311cb9be10610c30e02f7f75920e779076840"},
+    {file = "cftime-1.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b694aead858872b7102f860d00439147df1d867ea8fbaafe0be787f7fa59c264"},
+    {file = "cftime-1.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8390ea907988b11a93fa263365ca6a4ea829378b1e24e48b1087803d6bb6089c"},
+    {file = "cftime-1.2.1-cp38-none-win32.whl", hash = "sha256:b4bb4ae6c6e44f4d8bc080042515e70423bec20f5279e49b564c0238dc4319ad"},
+    {file = "cftime-1.2.1-cp38-none-win_amd64.whl", hash = "sha256:650e3ca771f6b6e9d6984af007c1045eb77eae40f9342e2982a45162a097cac5"},
+    {file = "cftime-1.2.1.tar.gz", hash = "sha256:ab5d5076f7d3e699758a244ada7c66da96bae36e22b9e351ce0ececc36f0a57f"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -1063,6 +1145,26 @@ mccabe = [
 more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
     {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
+]
+netcdf4 = [
+    {file = "netCDF4-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c4192fa17493783b409c726048e5297591b2938e19fe7ec8f2769c859290a404"},
+    {file = "netCDF4-1.5.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a443c1523ec0449483e620ae17f92cfd59567bd50f8dfece6b7ee7a20e28249d"},
+    {file = "netCDF4-1.5.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ce5c4e42f8970ecbafb7f706648e03e8e1ec54a3db979a68f5cf49ff032ab06e"},
+    {file = "netCDF4-1.5.4-cp36-cp36m-win32.whl", hash = "sha256:af1eaadf3f0a1ef91c1f396c0b57d4a376db9459f6ae812e711404917b352a26"},
+    {file = "netCDF4-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:ff0db30eee3fe3d4dc18c6658e702b2a4859a3b94c1990177fea4660cebe3c37"},
+    {file = "netCDF4-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3dd358286f60afcb7d2df15362157a1821786ddb4bac10239849b0b751be91a7"},
+    {file = "netCDF4-1.5.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:eedd5d256a9393645bf06e9de97d8b744692217c426a03aca935fded43f5222f"},
+    {file = "netCDF4-1.5.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f3d224b6ea4017ba067a116b7ba4e56e7086bdfd41aa0ceceef12b8b85dbf6b3"},
+    {file = "netCDF4-1.5.4-cp37-cp37m-win32.whl", hash = "sha256:703bca7c85f86ec8d469dfd2b7e9d7e5b4e1be0224c8c7f6c03ea132e1b55069"},
+    {file = "netCDF4-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:355aafbd932f98bcc04d16b20cfad9bec07df8631fa41ae8d3992ab071d7e37e"},
+    {file = "netCDF4-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1dbc38bea9e50fd3476a6c9d8bcc871b8f36e194b40bb720584f7d3bb9c381b6"},
+    {file = "netCDF4-1.5.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b39e453d0ecf81bf61f2c2dca36a22149f680499ac0e06029c7fa9fa5cc2e41f"},
+    {file = "netCDF4-1.5.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:395f9d7dbdfc13111e5a6a99ced9c64f2ffdff39a21d9d100374e31170ea4875"},
+    {file = "netCDF4-1.5.4-cp38-cp38-win32.whl", hash = "sha256:368c1820b6a059887af5b5902717788b45df9db3318a4f3c9f683acb9af7bf43"},
+    {file = "netCDF4-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:26f073e09ce353c6b8f2baa4d20d41ae80bda19391110067968f0d2dfe0cba69"},
+    {file = "netCDF4-1.5.4-cp39-cp39-win32.whl", hash = "sha256:a3920a4a74ace672b12864cb505a4229dc86ce93ba299df0e933ed43f011d7a4"},
+    {file = "netCDF4-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:223b84f8d2a148e889b1933944109bdecbefc097200ab42e8a66c967b1398e1b"},
+    {file = "netCDF4-1.5.4.tar.gz", hash = "sha256:941de6f3623b6474ecb4d043be5990690f7af4cf0d593b31be912627fe5aad03"},
 ]
 nodeenv = [
     {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
@@ -1405,6 +1507,10 @@ virtualenv = [
 wheel = [
     {file = "wheel-0.34.2-py2.py3-none-any.whl", hash = "sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"},
     {file = "wheel-0.34.2.tar.gz", hash = "sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96"},
+]
+xarray = [
+    {file = "xarray-0.16.0-py3-none-any.whl", hash = "sha256:e38452dbbb9f7b1938ae23b81ca7d66d1109818040048ec42e59c0c738cbe8f3"},
+    {file = "xarray-0.16.0.tar.gz", hash = "sha256:665de4253fcf951e7a6954313b77164d7efca2bd820f0a518b7c25ea46ee43cb"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-bask = "^0.7.2"
+bask = "^0"
 Click = "^7.1.2"
 numpy = "^1.19.1"
 scipy = "^1.5.2"

--- a/tune/summary.py
+++ b/tune/summary.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+__all__ = ["confidence_intervals"]
+
+
+def _round_interval(interval, threshold=0.01, max_precision=32):
+    diff = interval[1] - interval[0]
+    if diff == 0:
+        return tuple(interval)
+    for i in range(max_precision):
+        rounded = np.around(interval, decimals=i)
+        diff_i = np.diff(rounded).item()
+        rel_error = abs(diff_i - diff) / diff
+        if (
+            rel_error <= threshold
+            and len(np.unique(rounded)) == 2
+            and rounded[0] < rounded[1]
+        ):
+            return tuple(np.around(interval, decimals=i))
+
+
+def _round_all_intervals(intervals, threshold=0.01, max_precision=32):
+    result = []
+    for dim in intervals:
+        sub_result = []
+        if hasattr(dim[0], "__len__"):
+            for sub in dim:
+                sub_result.append(
+                    _round_interval(
+                        sub, threshold=threshold, max_precision=max_precision
+                    )
+                )
+        else:
+            sub_result.append(
+                _round_interval(dim, threshold=threshold, max_precision=max_precision)
+            )
+        result.append(sub_result)
+    return result
+
+
+def confidence_intervals(
+    optimizer,
+    param_names=None,
+    hdi_prob=0.95,
+    multimodal=True,
+    opt_samples=200,
+    space_samples=500,
+    only_mean=True,
+    random_state=None,
+    max_precision=32,
+    threshold=0.01,
+):
+    if param_names is None:
+        param_names = [
+            "Parameter {}".format(i) for i in range(len(optimizer.space.dimensions))
+        ]
+    intervals = optimizer.optimum_intervals(
+        hdi_prob=hdi_prob,
+        multimodal=multimodal,
+        opt_samples=opt_samples,
+        space_samples=space_samples,
+        only_mean=only_mean,
+        random_state=random_state,
+    )
+    rounded = _round_all_intervals(
+        intervals, max_precision=max_precision, threshold=threshold
+    )
+    max_param_length = max(max((len(x) for x in param_names)), 9)
+    max_lb = max(max(len(str(row[0])) for sub in rounded for row in sub), 11)
+    max_ub = max(max(len(str(row[1])) for sub in rounded for row in sub), 11)
+    format_string = "{:<{}}  {:>{}}  {:>{}}\n"
+    output = format_string.format(
+        "Parameter", max_param_length, "Lower bound", max_lb, "Upper bound", max_ub
+    )
+    output += "{:-^{}}\n".format("", max_param_length + max_lb + max_ub + 4)
+    for sub, name, dim in zip(rounded, param_names, optimizer.space.dimensions):
+        for i, interval in enumerate(sub):
+            if i == 0:
+                name_out = name
+            else:
+                name_out = ""
+            output += format_string.format(
+                name_out, max_param_length, interval[0], max_lb, interval[1], max_ub
+            )
+    return output


### PR DESCRIPTION
Motivation
-----------
Using the `tune local` script it is still difficult to gauge, how certain the model is about the location of the global optimum. We plot the "pessimistic optimum" in orange, but that is only a weak indicator for convergence.

Pull request
------------
This pull request utilizes the new "confidence interval" functionality provided by [bask](https://github.com/kiudee/bayes-skopt). Every time the global optimum is reported in the log, it will also print a table containing the estimated highest density intervals for each parameter. It does so by repeatedly sampling an optimization landscape from the model, determining its optimum and using that to construct a histogram for each parameter. Then the regions of highest density are selected from the histograms as confidence intervals.

Closes #36 