### PR TITLE
Allow cutechess-cli result parser to correctly parse cutechess-cli 1.2.0 output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.5.0-beta.3 (2020-08-12)
+-------------------------
+* Add support for the new cutechess-cli 1.2.0 output format.
+
 0.5.0-beta.2 (2020-08-10)
 -------------------------
 * Add support for confidence intervals of the optimum. By default a table of

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -19,6 +19,29 @@ def test_parse_experiment_result():
     assert_almost_equal(score, 0.0)
     assert_almost_equal(error, 0.06, decimal=2)
 
+    # Test cutechess 1.2.0 output:
+    teststr = """Started game 1 of 4 (engine1 vs engine2)
+    Finished game 1 (engine1 vs engine2): 0-1 {Black mates}
+    Score of engine1 vs engine2: 0 - 1 - 0  [0.000] 1
+    Started game 2 of 4 (engine2 vs engine1)
+    Finished game 2 (engine2 vs engine1): 1/2-1/2 {Draw by stalemate}
+    Score of engine1 vs engine2: 0 - 1 - 1  [0.250] 2
+    Started game 3 of 4 (engine1 vs engine2)
+    Finished game 3 (engine1 vs engine2): 0-1 {Black mates}
+    Score of engine1 vs engine2: 0 - 2 - 1  [0.167] 3
+    Started game 4 of 4 (engine2 vs engine1)
+    Finished game 4 (engine2 vs engine1): 0-1 {Black mates}
+    Score of engine1 vs engine2: 1 - 2 - 1  [0.375] 4
+    ...      engine1 playing White: 0 - 2 - 0  [0.000] 2
+    ...      engine1 playing Black: 1 - 0 - 1  [0.750] 2
+    ...      White vs Black: 0 - 3 - 1  [0.125] 4
+    Elo difference: -88.7 +/- nan, LOS: 28.2 %, DrawRatio: 25.0 %
+    Finished match
+    """
+    score, error = parse_experiment_result(teststr, n_dirichlet_samples=1000)
+    assert_almost_equal(score, 1 / 9)
+    assert_almost_equal(error, 0.04, decimal=2)
+
 
 def test_reduce_ranges():
     space = normalize_dimensions([(0.0, 1.0), ("a", "b", "c")])

--- a/tune/local.py
+++ b/tune/local.py
@@ -49,7 +49,7 @@ def parse_experiment_result(
         Estimated standard error of the score. Estimated by repeated draws
         from a Dirichlet distribution.
     """
-    wdl_strings = re.findall(r"[0-9]+\s-\s[0-9]+\s-\s[0-9]+", outstr)
+    wdl_strings = re.findall(r"Score of.*([0-9]+\s-\s[0-9]+\s-\s[0-9]+)", outstr)
     array = np.array(
         [np.array([int(y) for y in re.findall(r"[0-9]+", x)]) for x in wdl_strings]
     )


### PR DESCRIPTION
Right now the cutechess-cli result parser takes everything which looks like a
wdl string and uses those counts to compute a pentanomial distribution.
This does not work for cutechess-cli 1.2.0 anymore, since it outputs
additional wdl statistics at the end of a match.

This pull request fixes the regular expression to work with the old and new output.
The test is adjusted to test both strings.

Fixes #55
