### PR TITLE
Fix problem in new match parser

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -46,6 +46,44 @@ def test_parse_experiment_result():
     assert_almost_equal(score, 0.38764005203222596)
     assert_almost_equal(error, 0.6255020676255081)
 
+    teststr = """Indexing opening suite...
+    Started game 1 of 40 (engine1 vs engine2)
+    Finished game 1 (engine1 vs engine2): 1/2-1/2 {Draw by 3-fold repetition}
+    Score of engine1 vs engine2: 1 - 0 - 0  [0.500] 1
+    Started game 2 of 40 (engine2 vs engine1)
+    Finished game 2 (engine2 vs engine1): 1/2-1/2 {Draw by adjudication: SyzygyTB}
+    Score of engine1 vs engine2: 2 - 0 - 0  [0.500] 2
+    Started game 3 of 40 (engine1 vs engine2)
+    Finished game 3 (engine1 vs engine2): 0-1 {Black wins by adjudication}
+    Score of engine1 vs engine2: 3 - 0 - 0  [0.333] 3
+    Started game 4 of 40 (engine2 vs engine1)
+    Finished game 4 (engine2 vs engine1): 0-1 {Black wins by adjudication}
+    Score of engine1 vs engine2: 4 - 0 - 0  [0.500] 4
+    Started game 5 of 40 (engine1 vs engine2)
+    Finished game 5 (engine1 vs engine2): 1-0 {White wins by adjudication}
+    Score of engine1 vs engine2: 5 - 0 - 0  [0.600] 5
+    Started game 6 of 40 (engine2 vs engine1)
+    Finished game 6 (engine2 vs engine1): 1-0 {White wins by adjudication}
+    Score of engine1 vs engine2: 6 - 0 - 0  [0.500] 6
+    Started game 7 of 40 (engine1 vs engine2)
+    Finished game 7 (engine1 vs engine2): 0-1 {Black wins by adjudication}
+    Score of engine1 vs engine2: 7 - 0 - 0  [0.429] 7
+    Started game 8 of 40 (engine2 vs engine1)
+    Finished game 8 (engine2 vs engine1): 0-1 {Black wins by adjudication}
+    Score of engine1 vs engine2: 8 - 0 - 0  [0.500] 8
+    Started game 9 of 40 (engine1 vs engine2)
+    Finished game 9 (engine1 vs engine2): 0-1 {Black wins by adjudication}
+    Score of engine1 vs engine2: 9 - 0 - 0  [0.444] 9
+    Started game 10 of 40 (engine2 vs engine1)
+    Finished game 10 (engine2 vs engine1): 1/2-1/2 {Draw by adjudication}
+    Score of engine1 vs engine2: 10 - 0 - 0  [0.450] 10
+    """
+    score, error = parse_experiment_result(
+        teststr, n_dirichlet_samples=1000, random_state=0
+    )
+    assert_almost_equal(score, -2.7958800173440745)
+    assert_almost_equal(error, 1.9952678343378125)
+
 
 def test_reduce_ranges():
     space = normalize_dimensions([(0.0, 1.0), ("a", "b", "c")])

--- a/tune/local.py
+++ b/tune/local.py
@@ -120,7 +120,7 @@ def parse_experiment_result(
         Estimated standard error of the score. Estimated by repeated draws
         from a Dirichlet distribution.
     """
-    wdl_strings = re.findall(r"Score of.*([0-9]+\s-\s[0-9]+\s-\s[0-9]+)", outstr)
+    wdl_strings = re.findall(r"Score of.*:\s*([0-9]+\s-\s[0-9]+\s-\s[0-9]+)", outstr)
     array = np.array(
         [np.array([int(y) for y in re.findall(r"[0-9]+", x)]) for x in wdl_strings]
     )


### PR DESCRIPTION
The regular expression of the new parser was capturing the first digits of the WLD string. This caused scores too be incorrect when the number of wins was at least two digits.