### PR TITLE
Support the new input warping feature by bayes-skopt

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.6.0-beta.3 (2020-09-02)
+-------------------------
+* Add support for input warping, allowing the tuner to automatically transform
+  the data into a suitable form (internally).
+
 0.6.0-beta.2 (2020-08-25)
 -------------------------
 * Fix plots being of varying sizes dependent on their labels and ticks.

--- a/docs/parameters.myst
+++ b/docs/parameters.myst
@@ -119,6 +119,14 @@ fitting process:
   - Size of initial dense set of points to try before using the GP model to
     select points. Too few points can make the inference of the model unstable,
     especially when an exploitative `acq_function` is used. [default: 30]
+* - `"warp_inputs"`
+  - `--warp-inputs/--no-warp-inputs`
+  - If True, the tuner will try to transform the input variables in such a way
+    that it ensures a good fit of the Gaussian process.
+    To be more precise, the cumulative distribution function of a beta
+    distribution is used to warp the input space. The parameters of the beta
+    distributions are estimated jointly with those of the GP. [default: True]
+
 ```
 
 [bask]: https://github.com/kiudee/bayes-skopt

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,7 +122,7 @@ description = "A fully Bayesian implementation of sequential model-based optimiz
 name = "bask"
 optional = false
 python-versions = ">=3.7,<4.0"
-version = "0.8.0"
+version = "0.9.0"
 
 [package.dependencies]
 Click = ">=7.1.2,<8.0.0"
@@ -1109,7 +1109,7 @@ version = "2.8.5"
 [[package]]
 category = "main"
 description = "Run a subprocess in a pseudo terminal"
-marker = "sys_platform != \"win32\" or os_name != \"nt\" or python_version >= \"3.3\" and sys_platform != \"win32\""
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\" or os_name != \"nt\" or python_version >= \"3.3\" and sys_platform != \"win32\" and (python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\")"
 name = "ptyprocess"
 optional = false
 python-versions = "*"
@@ -1785,7 +1785,7 @@ dist = ["joblib", "psycopg2", "sqlalchemy", "pandas"]
 docs = ["Sphinx", "sphinx-book-theme", "myst-nb"]
 
 [metadata]
-content-hash = "0b96c3b5f204bf0f44c6befbe1cb8df3af90525df08f485b6019c680cbb68087"
+content-hash = "8d6332b39353743a635e50ad7eeb155c8a9a3b365f43c7f7a82216c8df67fdb0"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1849,8 +1849,8 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 bask = [
-    {file = "bask-0.8.0-py3-none-any.whl", hash = "sha256:362cf410ca3412e70c70ad2e7d0687aa179fe41345c6cfaa3d58833f7ed09ac4"},
-    {file = "bask-0.8.0.tar.gz", hash = "sha256:d022af687f610060dcb37e8c3181bccf82f673ed2ead45d057997346f682bbe4"},
+    {file = "bask-0.9.0-py3-none-any.whl", hash = "sha256:176f80ec06a40916f063af1ef6e17bc52a101ef53d7b9f25abf1a53f6bafb324"},
+    {file = "bask-0.9.0.tar.gz", hash = "sha256:6d62557d570ae0170260e90979a714b136d746d861dbb1241de41f2d4dc712b7"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.1-py2-none-any.whl", hash = "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-bask = ">=0.8.0, <1.0.0"
+bask = ">=0.9.0,<1.0.0"
 Click = "^7.1.2"
 numpy = "^1.19.1"
 scipy = "^1.5.2"


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gaussian processes assume a stationary process. Most real-world functions are non-stationary which can cause convergence issues. In addition it places a burden on the user to be careful when specifying the ranges for the parameters and to know when to specify a log-transformation.
This pull request adds input warping using beta distributions, which can produce log-, exp-, logistic- and sigmoidal-like transformations. The hyperparameters are inferred jointly with all the other kernel hyperparameters.

## Description
To activate input warping, set the parameter `warp_inputs=True`. The warping is done internally and on-the-fly. There is no change to the data itself and it can be turned on/off during a tuning run.

The change requires `bask>=0.9.0` and the dependencies were updated accordingly.

Reference:
[Input warping for Bayesian optimization of non-stationary functions](https://dl.acm.org/doi/10.5555/3044805.3045079)