### PR TITLE
Fix model not being informed about noise variance

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+0.7.0-beta.3 (2020-11-22)
+-------------------------
+* Fix a bug where the model was not informed about the estimated noise variance
+  of the current match.
+
 0.7.0-beta.2 (2020-10-13)
 -------------------------
 * Revert default acquisition function back to ``"mes"``.

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -469,21 +469,14 @@ def local(  # noqa: C901
                 if opt.gp.chain_ is None:
                     gp_burnin = settings.get("gp_initial_burnin", gp_initial_burnin)
                     gp_samples = settings.get("gp_initial_samples", gp_initial_samples)
-                    opt.tell(
-                        point,
-                        score,
-                        n_samples=n_samples,
-                        gp_samples=gp_samples,
-                        gp_burnin=gp_burnin,
-                    )
-                else:
-                    opt.tell(
-                        point,
-                        score,
-                        n_samples=n_samples,
-                        gp_samples=gp_samples,
-                        gp_burnin=gp_burnin,
-                    )
+                opt.tell(
+                    point,
+                    score,
+                    noise_vector=error,
+                    n_samples=n_samples,
+                    gp_samples=gp_samples,
+                    gp_burnin=gp_burnin,
+                )
                 later = datetime.now()
                 difference = (later - now).total_seconds()
                 root_logger.info(f"GP sampling finished ({difference}s)")


### PR DESCRIPTION
We estimate the noise of each chess match using a Bayesian pentanomial model. If this noise estimate is not passed into the optimizer, it will simply assume that the noise is the same across the parameter space. This is not true of course, since the variance changes with Elo strength.
While this looks like a minor bug, this was actually weakening the search quite a bit and in addition caused odd behavior when resuming the optimizer. The noise variance was passed correctly for the data used for resuming.

Thanks to @Claes1981 for finding this bug.
Fixes #111.