### PR TITLE
Correctly output standard deviation instead of variance for score estimate

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.7.1 (2020-12-08)
+------------------
+* Fix incorrectly outputting the variance instead of the standard deviation for
+  the estimated error around the score estimate.
+
 0.7.0 (2020-11-22)
 ------------------
 * Fix a bug where the model was not informed about the estimated noise variance

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -456,8 +456,8 @@ def local(  # noqa: C901
         difference = (later - now).total_seconds()
         root_logger.info(f"Experiment finished ({difference}s elapsed).")
 
-        score, error = parse_experiment_result(out_exp, **settings)
-        root_logger.info("Got score: {} +- {}".format(score, error))
+        score, error_variance = parse_experiment_result(out_exp, **settings)
+        root_logger.info("Got score: {} +- {}".format(score, np.sqrt(error_variance)))
         root_logger.info("Updating model")
         while True:
             try:
@@ -472,7 +472,7 @@ def local(  # noqa: C901
                 opt.tell(
                     point,
                     score,
-                    noise_vector=error,
+                    noise_vector=error_variance,
                     n_samples=n_samples,
                     gp_samples=gp_samples,
                     gp_burnin=gp_burnin,
@@ -506,7 +506,7 @@ def local(  # noqa: C901
                 break
         X.append(point)
         y.append(score)
-        noise.append(error)
+        noise.append(error_variance)
         iteration = len(X)
 
         with AtomicWriter(data_path, mode="wb", overwrite=True).open() as f:


### PR DESCRIPTION
Pretty much does what it says on the tin. To prevent further confusion, the variable name was changed to `error_variance` to be more clear.