### PR TITLE
Interpretable Elo scores

### DIFF
--- a/tune/cli.py
+++ b/tune/cli.py
@@ -371,15 +371,15 @@ def local(  # noqa: C901
                     )
                 root_logger.info(f"Current optimum:\n{best_point_dict}")
                 root_logger.info(
-                    f"Estimated value: {np.around(best_value, 4)} +- "
-                    f"{np.around(best_std, 4).item()}"
+                    f"Estimated Elo: {np.around(-best_value * 100, 4)} +- "
+                    f"{np.around(best_std * 100, 4).item()}"
                 )
                 confidence_val = settings.get("confidence", confidence)
                 confidence_mult = erfinv(confidence_val) * np.sqrt(2)
                 root_logger.info(
                     f"{confidence_val * 100}% confidence interval of the value: "
-                    f"({np.around(best_value - confidence_mult * best_std, 4).item()}, "
-                    f"{np.around(best_value + confidence_mult * best_std, 4).item()})"
+                    f"({np.around(-best_value * 100 - confidence_mult * best_std * 100, 4).item()}, "
+                    f"{np.around(-best_value * 100 + confidence_mult * best_std * 100, 4).item()})"
                 )
                 confidence_out = confidence_intervals(
                     optimizer=opt,
@@ -457,7 +457,7 @@ def local(  # noqa: C901
         root_logger.info(f"Experiment finished ({difference}s elapsed).")
 
         score, error_variance = parse_experiment_result(out_exp, **settings)
-        root_logger.info("Got score: {} +- {}".format(score, np.sqrt(error_variance)))
+        root_logger.info("Got Elo: {} +- {}".format(-score * 100, np.sqrt(error_variance) * 100))
         root_logger.info("Updating model")
         while True:
             try:

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -377,7 +377,7 @@ def local(  # noqa: C901
                 confidence_val = settings.get("confidence", confidence)
                 confidence_mult = erfinv(confidence_val) * np.sqrt(2)
                 root_logger.info(
-                    f"{confidence_val * 100}% confidence interval of the value: "
+                    f"{confidence_val * 100}% confidence interval of the Elo value: "
                     f"({np.around(-best_value * 100 - confidence_mult * best_std * 100, 4).item()}, "
                     f"{np.around(-best_value * 100 + confidence_mult * best_std * 100, 4).item()})"
                 )


### PR DESCRIPTION
This (seems to) partially address the score interpretability problem, by printing the Elo equivalent to the score.

To be checked: whether I've scaled stuff correctly
Still to be done: make the charts use the same scale
Maybe to be done: document the change? This might make things *more* confusing to existing users of the tool.

It also seems like the commit history is messed up, so maybe if you merge just squash it? Not sure how to deal with it.

Fixes #113 