### PR TITLE
Fix computation of the expected score

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.7.2 (unreleased)
+------------------
+* Fix computation of the score estimate. This should help in tunes with a low
+  number of rounds.
+
 0.7.1 (2020-12-08)
 ------------------
 * Fix incorrectly outputting the variance instead of the standard deviation for

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -18,7 +18,7 @@ def test_parse_experiment_result():
     score, error = parse_experiment_result(
         teststr, n_dirichlet_samples=1000, random_state=0
     )
-    assert_almost_equal(score, 0.0)
+    assert_almost_equal(score, 0.020911252464146674)
     assert_almost_equal(error, 0.887797821633887)
 
     # Test cutechess 1.2.0 output:
@@ -43,7 +43,7 @@ def test_parse_experiment_result():
     score, error = parse_experiment_result(
         teststr, n_dirichlet_samples=1000, random_state=0
     )
-    assert_almost_equal(score, 0.38764005203222596)
+    assert_almost_equal(score, 0.37790743267692595)
     assert_almost_equal(error, 0.6255020676255081)
 
     teststr = """Indexing opening suite...
@@ -81,7 +81,7 @@ def test_parse_experiment_result():
     score, error = parse_experiment_result(
         teststr, n_dirichlet_samples=1000, random_state=0
     )
-    assert_almost_equal(score, -2.7958800173440745)
+    assert_almost_equal(score, -3.2141142610031594)
     assert_almost_equal(error, 1.9952678343378125)
 
 

--- a/tune/local.py
+++ b/tune/local.py
@@ -149,11 +149,12 @@ def parse_experiment_result(
         raise ValueError("Argument prior_counts should contain 5 elements.")
     dist = dirichlet(alpha=counts_array + prior_counts)
     scores = [0.0, 0.25, 0.5, 0.75, 1.0]
-    score = prob_to_elo(dist.mean().dot(scores), k=score_scale)
-    error = prob_to_elo(
+    samples = prob_to_elo(
         dist.rvs(n_dirichlet_samples, random_state=random_state).dot(scores),
         k=score_scale,
-    ).var()
+    )
+    score = samples.mean()
+    error = samples.var()
     return score, error
 
 


### PR DESCRIPTION
The code did incorrectly compute the expectation of the Dirichlet distribution first and then computed the outer expectation.
Now we first sample vectors from the Dirichlet distribution and then average them.
The effect is especially noticeable for tunes with low number of rounds.

Related to #118 
 