### PR TITLE
Implement fast resume functionality

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 0.7.3 (2021-06-26)
 ------------------
+* Add ``--fast-resume`` switch to the tuner, which allows instant resume
+  functionality from disk (new default).
 * Fix the match parser producing incorrect results, when concurrency > 1 is
   used for playing matches.
 * Fix the server for distributed tuning trying to compute the current optimum

--- a/docs/parameters.myst
+++ b/docs/parameters.myst
@@ -323,6 +323,17 @@ fitting process:
   - Let the optimizer resume, if it finds points it can use.
     [default: True]
 * -
+  - `--fast-resume / --no-fast-resume`
+  - If set, resume the tuning process with the model in the file specified by
+    the `--model-path`.
+    Note, that a full reinitialization will be performed, if the parameter
+    ranges have been changed.
+    [default: True]
+* -
+  - `--model-path PATH`
+  - The current optimizer will be saved for fast resuming to this file.
+    [default: model.pkl]
+* -
   - `-v --verbose`
   - Turn on debug output. `-vv` turns on the debug flag for cutechess-cli.
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -286,6 +286,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "dill"
+version = "0.3.4"
+description = "serialize all of python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*"
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+
+[[package]]
 name = "distlib"
 version = "0.3.2"
 description = "Distribution utilities"
@@ -1830,7 +1841,7 @@ docs = ["Sphinx", "sphinx-book-theme", "myst-nb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9d1529891e8cc84aa66894d5df022e98dace0efb7c07e36fed6a55b3b9c8a741"
+content-hash = "a6d693d15e6c5f13be59aa30dc98ff90e5a32587ae77eccd585e896016b72d2b"
 
 [metadata.files]
 alabaster = [
@@ -2027,6 +2038,10 @@ decorator = [
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
+dill = [
+    {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
+    {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
 ]
 distlib = [
     {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ scikit-optimize = "^0.8"
 emcee = "^3.0.2"
 atomicwrites = "^1.4.0"
 scikit-learn = ">=0.22,<0.24"
+dill = "^0.3.4"
 joblib = {version = "^0.16.0", optional = true}
 psycopg2 = {version = "^2.8.5", optional = true}
 sqlalchemy = {version = "^1.3.18", optional = true}

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -239,7 +239,7 @@ def run_server(verbose, logfile, command, experiment_file, dbconfig):
 @click.option(
     "--model-path",
     default="model.pkl",
-    help="The current optimizer will be saved for resuming to this file.",
+    help="The current optimizer will be saved for fast resuming to this file.",
     type=click.Path(exists=False),
     show_default=True,
 )

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -7,6 +7,7 @@ import time
 from datetime import datetime
 
 import click
+import dill
 import matplotlib.pyplot as plt
 import numpy as np
 from atomicwrites import AtomicWriter
@@ -226,6 +227,22 @@ def run_server(verbose, logfile, command, experiment_file, dbconfig):
     help="Let the optimizer resume, if it finds points it can use.",
     show_default=True,
 )
+@click.option(
+    "--fast-resume/--no-fast-resume",
+    default=True,
+    help="If set, resume the tuning process with the model in the file specified by"
+    " the --model-path. "
+    "Note, that a full reinitialization will be performed, if the parameter"
+    "ranges have been changed.",
+    show_default=True,
+)
+@click.option(
+    "--model-path",
+    default="model.pkl",
+    help="The current optimizer will be saved for resuming to this file.",
+    type=click.Path(exists=False),
+    show_default=True,
+)
 @click.option("--verbose", "-v", count=True, default=0, help="Turn on debug output.")
 @click.option(
     "--warp-inputs/--no-warp-inputs",
@@ -252,6 +269,8 @@ def local(  # noqa: C901
     random_seed=0,
     result_every=1,
     resume=True,
+    fast_resume=True,
+    model_path="model.pkl",
     verbose=0,
     warp_inputs=True,
 ):
@@ -278,6 +297,7 @@ def local(  # noqa: C901
     ss = np.random.SeedSequence(settings.get("random_seed", random_seed))
     # 2. Create kernel
     # 3. Create optimizer
+
     random_state = np.random.RandomState(np.random.MT19937(ss.spawn(1)[0]))
     gp_kwargs = dict(
         # TODO: Due to a bug in scikit-learn 0.23.2, we set normalize_y=False:
@@ -336,21 +356,43 @@ def local(  # noqa: C901
                 X = X_reduced
                 y = y_reduced
                 noise = noise_reduced
-
             iteration = len(X)
-            root_logger.info(
-                f"Importing {iteration} existing datapoints. This could take a while..."
-            )
-            opt.tell(
-                X,
-                y,
-                noise_vector=noise,
-                gp_burnin=settings.get("gp_initial_burnin", gp_initial_burnin),
-                gp_samples=settings.get("gp_initial_samples", gp_initial_samples),
-                n_samples=settings.get("n_samples", 1),
-                progress=True,
-            )
-            root_logger.info("Importing finished.")
+            reinitialize = True
+            if fast_resume:
+                path = pathlib.Path(model_path)
+                if path.exists():
+                    with open(model_path, mode="rb") as model_file:
+                        old_opt = dill.load(model_file)
+                        root_logger.info(
+                            f"Resuming from existing optimizer in {model_path}."
+                        )
+                    if opt.space == old_opt.space:
+                        old_opt.acq_func = opt.acq_func
+                        old_opt.acq_func_kwargs = opt.acq_func_kwargs
+                        opt = old_opt
+                        reinitialize = False
+                    else:
+                        root_logger.info(
+                            "Parameter ranges have been changed and the "
+                            "existing optimizer instance is no longer "
+                            "valid. Reinitializing now."
+                        )
+
+            if reinitialize:
+                root_logger.info(
+                    f"Importing {iteration} existing datapoints. "
+                    f"This could take a while..."
+                )
+                opt.tell(
+                    X,
+                    y,
+                    noise_vector=noise,
+                    gp_burnin=settings.get("gp_initial_burnin", gp_initial_burnin),
+                    gp_samples=settings.get("gp_initial_samples", gp_initial_samples),
+                    n_samples=settings.get("n_samples", 1),
+                    progress=True,
+                )
+                root_logger.info("Importing finished.")
 
     # 4. Main optimization loop:
     while True:
@@ -457,7 +499,9 @@ def local(  # noqa: C901
         root_logger.info(f"Experiment finished ({difference}s elapsed).")
 
         score, error_variance = parse_experiment_result(out_exp, **settings)
-        root_logger.info("Got Elo: {} +- {}".format(-score * 100, np.sqrt(error_variance) * 100))
+        root_logger.info(
+            "Got Elo: {} +- {}".format(-score * 100, np.sqrt(error_variance) * 100)
+        )
         root_logger.info("Updating model")
         while True:
             try:
@@ -511,6 +555,8 @@ def local(  # noqa: C901
 
         with AtomicWriter(data_path, mode="wb", overwrite=True).open() as f:
             np.savez_compressed(f, np.array(X), np.array(y), np.array(noise))
+        with AtomicWriter(model_path, mode="wb", overwrite=True).open() as f:
+            dill.dump(opt, f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request saves the complete optimizer object to disk using the library [dill](https://pypi.org/project/dill/).
The optimizer will be saved to the path specified by `--model-path`.
The user can then specify `--fast-resume` and the tuning process will instantly resume instead of having to perform a costly re-initialization.


Closes #124 