### PR TITLE
Only compute optimum in tuning server, if model has been fit.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.7.3 (2021-06-26)
+------------------
+* Fix the server for distributed tuning trying to compute the current optimum
+  before a model has been fit.
+
 0.7.2 (2021-03-22)
 ------------------
 * Print user facing scores using the more common Elo scale, instead of negative

--- a/tune/db_workers/tuning_server.py
+++ b/tune/db_workers/tuning_server.py
@@ -415,16 +415,22 @@ class TuningServer(object):
             self.logger.info("New jobs committed to database.")
             sleep(self.experiment.get("sleep_time", 60))
 
-            result_object = create_result(
-                Xi=X.tolist(), yi=y.tolist(), space=self.opt.space, models=[self.opt.gp]
-            )
-            try:
-                opt_x, opt_y = expected_ucb(result_object)
-                self.logger.info(
-                    f"Current optimum: {dict(zip(self.parameters, np.around(opt_x,4)))}"
+            if self.opt.gp.chain_ is not None:
+                result_object = create_result(
+                    Xi=X.tolist(),
+                    yi=y.tolist(),
+                    space=self.opt.space,
+                    models=[self.opt.gp],
                 )
-            except ValueError:
-                self.logger.info("Current optimum: None (optimizer errored out :( )")
+                try:
+                    opt_x, opt_y = expected_ucb(result_object)
+                    self.logger.info(
+                        f"Current optimum: {dict(zip(self.parameters, np.around(opt_x,4)))}"
+                    )
+                except ValueError:
+                    self.logger.info(
+                        "Current optimum: None (optimizer errored out :( )"
+                    )
 
     def deactivate(self):
         raise NotImplementedError


### PR DESCRIPTION
This pull request lets the tuning server check, if the GP model has been fit before computing the current optimum.

Fixes #127.