### PR TITLE
Save optimizer object to disk in tuning server

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-0.7.3 (2021-06-26)
+0.7.3 (2021-06-27)
 ------------------
 * Add ``--fast-resume`` switch to the tuner, which allows instant resume
   functionality from disk (new default).
@@ -11,6 +11,8 @@ History
 * Add ``--skip-benchmark`` flag to distributed tuning client. If True, it will
   skip the calibration of the time control, which involves running a benchmark
   for both engines.
+* Tuning server of the distributed tuning framework will now also save the
+  optimizer object.
 * Fix the match parser producing incorrect results, when concurrency > 1 is
   used for playing matches.
 * Fix the server for distributed tuning trying to compute the current optimum

--- a/tune/db_workers/tuning_server.py
+++ b/tune/db_workers/tuning_server.py
@@ -7,6 +7,8 @@ import sys
 from datetime import datetime
 from time import sleep
 
+import dill
+
 try:
     import joblib
 except ImportError:
@@ -102,6 +104,8 @@ class TuningServer(object):
         np.savez_compressed(
             path, np.array(self.opt.gp.pos_), np.array(self.opt.gp.chain_)
         )
+        with open("model.pkl", mode="wb") as file:
+            dill.dump(self.opt, file)
 
     def resume_tuning(self):
         path = os.path.join(


### PR DESCRIPTION
This pull request closes #133 by adding a `dill.dump` call to the tuning server.
That way the full optimizer object and the model can easily be extracted.