### PR TITLE
Add warp_inputs as option for the tuning server

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
   optimizer object.
 * Tuning server now also uses the updated pentanomial model including
   noise estimation.
+* ``warp_inputs`` can now be passed via database to the tuning server.
 * Fix the match parser producing incorrect results, when concurrency > 1 is
   used for playing matches.
 * Fix the server for distributed tuning trying to compute the current optimum

--- a/tune/db_workers/tuning_server.py
+++ b/tune/db_workers/tuning_server.py
@@ -203,7 +203,9 @@ class TuningServer(object):
                 "n_initial_points", 5 * len(self.dimensions)
             ),
             gp_kernel=self.kernel,
-            gp_kwargs=dict(normalize_y=True),
+            gp_kwargs=dict(
+                normalize_y=True, warp_inputs=self.tunecfg.get("warp_inputs", True)
+            ),
             gp_priors=self.priors,
             acq_func=self.tunecfg.get("acq_func", "ts"),
             acq_func_kwargs=self.tunecfg.get(


### PR DESCRIPTION
Closes #142 by fetching the option `warp_inputs` from the dictionary retrieved from the config file.