### PR TITLE
Support changing the Gaussian process prior parameters using the CLI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,21 @@
 History
 =======
 
+0.8.0 (2021-08-15)
+------------------
+
+Local tuner
+~~~~~~~~~~~
+
+* Replace default lengthscale priors by inverse-gamma distributions.
+* Add the following command line flags, which allow the user to override the
+  prior parameters:
+
+  - ``--gp-signal-prior-scale`` for the scale of the signal prior.
+  - ``--gp-noise-prior-scale`` for the scale of the noise prior.
+  - ``--gp-lengthscale-prior-lb`` for the lower bound of the lengthscale prior.
+  - ``--gp-lengthscale-prior-ub`` for the upper bound of the lengthscale prior.
+
 0.7.3 (2021-06-27)
 ------------------
 

--- a/docs/parameters.myst
+++ b/docs/parameters.myst
@@ -114,6 +114,32 @@ fitting process:
   - Number of model parameters to sample for the initial model. This is only
     used when resuming or for the first model. Should be a multiple of 100.
     [default: 300]
+* - `"gp_signal_prior_scale"`
+  - `--gp-signal-prior-scale FLOAT`
+  - Prior scale of the signal (standard deviation) magnitude which is used to
+    parametrize a half-normal distribution. Needs to be a number strictly
+    greater than 0.0.
+    [default: 4.0]
+* - `"gp_noise_prior_scale"`
+  - `--gp-noise-prior-scale FLOAT`
+  - Prior scale of the residual noise (standard deviation) which is used to
+    parametrize a half-normal distribution. Needs to be a number strictly
+    greater than 0.0.
+    [default: 0.0006]
+* - `"gp_lengthscale_prior_lb"`
+  - `--gp-lengthscale-prior-lb FLOAT`
+  - Lower bound for the inverse-gamma lengthscale prior.
+    It marks the point where the prior reaches 1% of the cumulative density.
+    Lower values favor non-smooth landscapes and higher values smooth ones.
+    Needs to be a number strictly greater than 0.0.
+    [default: 0.1]
+* - `"gp_lengthscale_prior_ub"`
+  - `--gp-lengthscale-prior-ub FLOAT`
+  - Upper bound for the inverse-gamma lengthscale prior.
+    It marks the point where the prior reaches 99% of the cumulative density.
+    Lower values favor non-smooth landscapes and higher values smooth ones.
+    Needs to be a number strictly greater than 0.0 and the lower bound.
+    [default: 0.5]
 * - `"n_initial_points"`
   - `--n-initial-points INTEGER`
   - Size of initial dense set of points to try before using the GP model to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chess-tuning-tools"
-version = "0.7.4"
+version = "0.8.0"
 description = "A collection of tools for local and distributed tuning of chess engines."
 authors = ["Karlson Pfannschmidt <kiudee@mail.upb.de>"]
 license = "Apache-2.0"

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -31,3 +31,8 @@ def test_create_priors():
     assert priors[2](2.0) == approx(-23.620792572134874)
     assert priors[3](2.0) == approx(-23.620792572134874)
     assert priors[4](2.0) == approx(-10262570.41553909)
+
+    with raises(ValueError):
+        create_priors(n_parameters=3, signal_scale=0.0)
+    with raises(ValueError):
+        create_priors(n_parameters=3, noise_scale=0.0)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pytest import approx, raises
 
-from tune.priors import make_invgamma_prior, roundflat
+from tune.priors import create_priors, make_invgamma_prior, roundflat
 
 
 def test_roundflat():
@@ -21,3 +21,13 @@ def test_make_invgamma_prior():
         make_invgamma_prior(upper_bound=-1e-10)
     with raises(ValueError):
         make_invgamma_prior(lower_bound=0.5, upper_bound=0.1)
+
+
+def test_create_priors():
+    priors = create_priors(n_parameters=3)
+    assert len(priors) == 5
+    assert priors[0](2.0) == approx(-1.536140897416146)
+    assert priors[1](2.0) == approx(-23.620792572134874)
+    assert priors[2](2.0) == approx(-23.620792572134874)
+    assert priors[3](2.0) == approx(-23.620792572134874)
+    assert priors[4](2.0) == approx(-10262570.41553909)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,11 +1,23 @@
 import numpy as np
-from numpy.testing import assert_almost_equal
+from pytest import approx, raises
 
-from tune.priors import roundflat
+from tune.priors import make_invgamma_prior, roundflat
 
 
 def test_roundflat():
-    assert_almost_equal(roundflat(0.3), 0.0, decimal=0.1)
-
+    assert roundflat(0.3) == approx(0.0, abs=1e-6)
     assert roundflat(0.0) == -np.inf
     assert roundflat(-1.0) == -np.inf
+
+
+def test_make_invgamma_prior():
+    prior = make_invgamma_prior()
+    assert prior.kwds["a"] == approx(8.919240823584246)
+    assert prior.kwds["scale"] == approx(1.7290248731437994)
+
+    with raises(ValueError):
+        make_invgamma_prior(lower_bound=-1e-10)
+    with raises(ValueError):
+        make_invgamma_prior(upper_bound=-1e-10)
+    with raises(ValueError):
+        make_invgamma_prior(lower_bound=0.5, upper_bound=0.1)

--- a/tune/priors.py
+++ b/tune/priors.py
@@ -1,11 +1,12 @@
 import warnings
+from typing import Callable, List
 
 import numpy as np
 from scipy.optimize import curve_fit
-from scipy.stats import invgamma
+from scipy.stats import halfnorm, invgamma
 from scipy.stats._distn_infrastructure import rv_frozen  # noqa
 
-__all__ = ["make_invgamma_prior", "roundflat"]
+__all__ = ["make_invgamma_prior", "roundflat", "create_priors"]
 
 
 def roundflat(x, a_low=2.0, a_high=8.0, d_low=0.005, d_high=1.2):
@@ -71,3 +72,60 @@ def make_invgamma_prior(
             [lower_bound, upper_bound],
         )
     return invgamma(a=a_out, scale=scale_out)
+
+
+def create_priors(
+    n_parameters: int,
+    signal_scale: float = 4.0,
+    lengthscale_lower_bound: float = 0.1,
+    lengthscale_upper_bound: float = 0.5,
+    noise_scale: float = 0.0006,
+) -> List[Callable[[float], float]]:
+    """Create a list of priors to be used for the hyperparameters of the tuning process.
+
+    Parameters
+    ----------
+    n_parameters : int
+        Number of parameters to be optimized.
+    signal_scale : float
+        Prior scale of the signal (standard deviation) which is used to parametrize a
+        half-normal distribution.
+    lengthscale_lower_bound : float
+        Lower bound of the inverse-gamma lengthscale prior. It marks the point at which
+        1 % of the cumulative density is reached.
+    lengthscale_upper_bound : float
+        Upper bound of the inverse-gamma lengthscale prior. It marks the point at which
+        99 % of the cumulative density is reached.
+    noise_scale : float
+        Prior scale of the noise (standard deviation) which is used to parametrize a
+        half-normal distribution.
+
+    Returns
+    -------
+    list of callables
+        List of priors in the following order:
+         - signal prior
+         - lengthscale prior (n_parameters times)
+         - noise prior
+    """
+    if signal_scale <= 0.0:
+        raise ValueError(
+            f"The signal scale needs to be strictly positive. Got {signal_scale}."
+        )
+    if noise_scale <= 0.0:
+        raise ValueError(
+            f"The noise scale needs to be strictly positive. Got {noise_scale}."
+        )
+    signal_prior = halfnorm(scale=signal_scale)
+    lengthscale_prior = make_invgamma_prior(
+        lower_bound=lengthscale_lower_bound, upper_bound=lengthscale_upper_bound
+    )
+    noise_prior = halfnorm(scale=noise_scale)
+
+    priors = [lambda x: signal_prior.logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)]
+    for _ in range(n_parameters):
+        priors.append(lambda x: lengthscale_prior.logpdf(np.exp(x)) + x)
+    priors.append(
+        lambda x: noise_prior.logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)
+    )
+    return priors


### PR DESCRIPTION
Rationale
======

Currently the hyperparameters of the Gaussian process priors are hardcoded and it is impossible for users to change them.
This can be useful, if the user (1) has prior knowledge regarding the effect of the parameters or (2) wants to bias the model towards overfitting for finetuning.

Description
=======
This pull request exposes four command line switches:

- `--gp-signal-prior-scale`: Specifying the prior standard deviation of the signal (how strong are the parameters influencing the strength).
- `--gp-noise-prior-scale`: Setting the prior standard deviation of the noise (how much residual variation is there in the estimated Elo score).
- `--gp-lengthscale-prior-lb`: The lower bound of the lengthscales, i.e., how non-smooth can the optimization landscape be.
- `--gp-lengthscale-prior-ub`: The upper bound of the lengthscales, i.e., how smooth can the optimization landscape be.

Closes #38 