### PR TITLE
Fix error at start when no data has been collected yet

### DIFF
--- a/tune/cli.py
+++ b/tune/cli.py
@@ -350,32 +350,25 @@ def local(  # noqa: C901
     while True:
         root_logger.info("Starting iteration {}".format(iteration))
 
-        # Print/plot results so far:
-        result_object = create_result(Xi=X, yi=y, space=opt.space, models=[opt.gp])
-        result_every_n = settings.get("result_every", result_every)
-        if (
-            result_every_n > 0
-            and iteration % result_every_n == 0
-            and opt.gp.chain_ is not None
-        ):
-            print_results(
-                optimizer=opt,
-                result_object=result_object,
-                parameter_names=list(param_ranges.keys()),
-                confidence=settings.get("confidence", confidence),
-            )
-        plot_every_n = settings.get("plot_every", plot_every)
-        if (
-            plot_every_n > 0
-            and iteration % plot_every_n == 0
-            and opt.gp.chain_ is not None
-        ):
-            plot_results(
-                optimizer=opt,
-                result_object=result_object,
-                plot_path=settings.get("plot_path", plot_path),
-                parameter_names=list(param_ranges.keys()),
-            )
+        # If a model has been fit, print/plot results so far:
+        if len(y) > 0 and opt.gp.chain_ is not None:
+            result_object = create_result(Xi=X, yi=y, space=opt.space, models=[opt.gp])
+            result_every_n = settings.get("result_every", result_every)
+            if result_every_n > 0 and iteration % result_every_n == 0:
+                print_results(
+                    optimizer=opt,
+                    result_object=result_object,
+                    parameter_names=list(param_ranges.keys()),
+                    confidence=settings.get("confidence", confidence),
+                )
+            plot_every_n = settings.get("plot_every", plot_every)
+            if plot_every_n > 0 and iteration % plot_every_n == 0:
+                plot_results(
+                    optimizer=opt,
+                    result_object=result_object,
+                    plot_path=settings.get("plot_path", plot_path),
+                    parameter_names=list(param_ranges.keys()),
+                )
 
         # Ask optimizer for next point:
         point = opt.ask()

--- a/tune/local.py
+++ b/tune/local.py
@@ -408,7 +408,7 @@ def initialize_optimizer(
                     "valid. Reinitializing now."
                 )
 
-    if reinitialize:
+    if reinitialize and len(X) > 0:
         logger.info(
             f"Importing {len(X)} existing datapoints. " f"This could take a while..."
         )


### PR DESCRIPTION
This pull request fixes a bug which occurs every time when the local tuner is run without any data to resume from. This was due to the result object being created which internally scans for the current best point, throwing an error if the list is empty.