### PR TITLE
Add 1D plotting functionality

### DIFF
--- a/tune/cli.py
+++ b/tune/cli.py
@@ -423,6 +423,7 @@ def local(  # noqa: C901
                     result_object=result_object,
                     plot_path=settings.get("plot_path", plot_path),
                     parameter_names=list(param_ranges.keys()),
+                    confidence=settings.get("confidence", confidence),
                 )
 
         # Ask optimizer for next point:

--- a/tune/local.py
+++ b/tune/local.py
@@ -14,7 +14,6 @@ import numpy as np
 from bask import Optimizer
 from numpy.random import RandomState
 from scipy.optimize import OptimizeResult
-from scipy.special import erfinv
 from scipy.stats import dirichlet
 from skopt.space import Categorical, Dimension, Integer, Real, Space
 from skopt.utils import normalize_dimensions
@@ -470,7 +469,7 @@ def print_results(
             f"Estimated Elo: {np.around(-best_value * 100, 4)} +- "
             f"{np.around(best_std * 100, 4).item()}"
         )
-        confidence_mult = erfinv(confidence) * np.sqrt(2)
+        confidence_mult = confidence_to_mult(confidence)
         lower_bound = np.around(
             -best_value * 100 - confidence_mult * best_std * 100, 4
         ).item()

--- a/tune/local.py
+++ b/tune/local.py
@@ -12,15 +12,16 @@ import dill
 import matplotlib.pyplot as plt
 import numpy as np
 from bask import Optimizer
+from matplotlib.transforms import Bbox
 from numpy.random import RandomState
 from scipy.optimize import OptimizeResult
 from scipy.stats import dirichlet
 from skopt.space import Categorical, Dimension, Integer, Real, Space
 from skopt.utils import normalize_dimensions
 
-from tune.plots import plot_objective
+from tune.plots import plot_objective, plot_objective_1d
 from tune.summary import confidence_intervals
-from tune.utils import TimeControl, expected_ucb
+from tune.utils import TimeControl, confidence_to_mult, expected_ucb
 
 __all__ = [
     "counts_to_penta",
@@ -505,6 +506,7 @@ def plot_results(
     result_object: OptimizeResult,
     plot_path: str,
     parameter_names: Sequence[str],
+    confidence: float = 0.9,
 ) -> None:
     """Plot the current results of the optimizer.
 
@@ -518,30 +520,38 @@ def plot_results(
         Path to the directory to which the plots should be saved.
     parameter_names : Sequence of str
         Names of the parameters to use for plotting.
+    confidence : float
+        The confidence level of the normal distribution to plot in the 1d plot.
     """
     logger = logging.getLogger(LOGGER)
-    if optimizer.space.n_dims == 1:
-        logger.warning("Plotting for only 1 parameter is not supported yet.")
-        return
     logger.debug("Starting to compute the next plot.")
-    plt.style.use("dark_background")
-    fig, ax = plt.subplots(
-        nrows=optimizer.space.n_dims,
-        ncols=optimizer.space.n_dims,
-        figsize=(3 * optimizer.space.n_dims, 3 * optimizer.space.n_dims),
-    )
-    fig.patch.set_facecolor("#36393f")
-    for i in range(optimizer.space.n_dims):
-        for j in range(optimizer.space.n_dims):
-            ax[i, j].set_facecolor("#36393f")
     timestr = time.strftime("%Y%m%d-%H%M%S")
-    plot_objective(result_object, dimensions=parameter_names, fig=fig, ax=ax)
+    dark_gray = "#36393f"
+    save_params = dict()
+    if optimizer.space.n_dims == 1:
+        fig, ax = plot_objective_1d(
+            result=result_object,
+            parameter_name=parameter_names[0],
+            confidence=confidence,
+        )
+        save_params["bbox_inches"] = Bbox([[0.5, -0.2], [9.25, 5.5]])
+    else:
+        plt.style.use("dark_background")
+        fig, ax = plt.subplots(
+            nrows=optimizer.space.n_dims,
+            ncols=optimizer.space.n_dims,
+            figsize=(3 * optimizer.space.n_dims, 3 * optimizer.space.n_dims),
+        )
+        for i in range(optimizer.space.n_dims):
+            for j in range(optimizer.space.n_dims):
+                ax[i, j].set_facecolor(dark_gray)
+        fig.patch.set_facecolor(dark_gray)
+        plot_objective(result_object, dimensions=parameter_names, fig=fig, ax=ax)
     plotpath = pathlib.Path(plot_path)
     plotpath.mkdir(parents=True, exist_ok=True)
     full_plotpath = plotpath / f"{timestr}-{len(optimizer.Xi)}.png"
-    plt.savefig(
-        full_plotpath, dpi=300, facecolor="#36393f",
-    )
+    dpi = 150 if optimizer.space.n_dims == 1 else 300
+    plt.savefig(full_plotpath, dpi=dpi, facecolor=dark_gray, **save_params)
     logger.info(f"Saving a plot to {full_plotpath}.")
     plt.close(fig)
 

--- a/tune/utils.py
+++ b/tune/utils.py
@@ -4,8 +4,15 @@ from decimal import Decimal
 
 import numpy as np
 from scipy.optimize import minimize
+from scipy.special import erfinv
 
-__all__ = ["expected_ucb", "parse_timecontrol", "TimeControl", "TimeControlBag"]
+__all__ = [
+    "confidence_to_mult",
+    "expected_ucb",
+    "parse_timecontrol",
+    "TimeControl",
+    "TimeControlBag",
+]
 
 
 def expected_ucb(res, n_random_starts=100, alpha=1.96, random_state=None):
@@ -106,3 +113,28 @@ class TimeControlBag(object):
             sorted_bag = sorted(tmp_bag)
             self.bag = [x[1] for x in sorted_bag]
         return self.bag.pop()
+
+
+def confidence_to_mult(confidence: float) -> float:
+    """Convert a confidence level to a multiplier for a standard deviation.
+
+    This assumes an underlying normal distribution.
+
+    Parameters
+    ----------
+    confidence: float [0, 1]
+        The confidence level to convert.
+
+    Returns
+    -------
+    float
+        The multiplier.
+
+    Raises
+    ------
+    ValueError
+        If the confidence level is not in the range [0, 1].
+    """
+    if confidence < 0 or confidence > 1:
+        raise ValueError("Confidence level must be in the range [0, 1].")
+    return erfinv(confidence) * np.sqrt(2)


### PR DESCRIPTION
This pull requests finally closes one of the oldest outstanding issues (#34).

It adds the following plot to the local tuner:
![20220124-221936-205](https://user-images.githubusercontent.com/564473/150869234-54ec89d1-9c3c-472b-950a-310f41f360c0.png)
It shows the following information:

- The mean process of the Gaussian process model.
- The confidence region of the mean process.
- The individual match Elo values in a second smaller plot below the main plot.
- The global optimum (red).
- The "conservative" optimum (orange), which depicts the point maximizing Elo - 1.96 * SE.

*Why are the individual Elo values not in the main plot?*
Since chess matches usually have a very low signal to noise ratio, including them in the main plot would blow up the plotting range and make it very hard to see the mean process. This can make it appear almost flat.

Closes #34