### PR TITLE
Save optima and Elo performance to disk

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -137,13 +137,15 @@ def test_reduce_ranges():
 
 def test_initialize_data(tmp_path):
     # Test basic functionality without resume:
-    X, y, noise, iteration = initialize_data(
+    X, y, noise, iteration, optima, performance = initialize_data(
         parameter_ranges=[(0.0, 1.0)], data_path=None, resume=False,
     )
     assert len(X) == 0
     assert len(y) == 0
     assert len(noise) == 0
     assert iteration == 0
+    assert len(optima) == 0
+    assert len(performance) == 0
     # Check if the created data structured are not exactly the same list:
     X.append(0)
     assert len(X) == 1
@@ -155,26 +157,30 @@ def test_initialize_data(tmp_path):
     X_in = np.array([[0.0], [0.5], [1.0]])
     y_in = np.array([1.0, -1.0, 0.0])
     noise_in = np.array([0.3, 0.2, 0.5])
-    np.savez_compressed(testfile, X_in, y_in, noise_in)
+    optima_in = np.array([[0.3]])
+    performance_in = np.array([[2.0, 30.0, 20.0]])
+    np.savez_compressed(testfile, X_in, y_in, noise_in, optima_in, performance_in)
 
     # Check if resume=False is recognized correctly
     # (outputs should be empty despite data_path being given):
-    X, _, _, _ = initialize_data(
+    X, _, _, _, _, _ = initialize_data(
         parameter_ranges=[(0.0, 1.0)], data_path=testfile, resume=False,
     )
     assert len(X) == 0
 
     # Check if we get the data back we saved with resume=True:
-    X, y, noise, iteration = initialize_data(
+    X, y, noise, iteration, optima, performance = initialize_data(
         parameter_ranges=[(0.0, 1.0)], data_path=testfile, resume=True,
     )
     assert iteration == 3
     assert np.allclose(X, X_in)
     assert np.allclose(y, y_in)
     assert np.allclose(noise, noise_in)
+    assert np.allclose(optima, optima_in)
+    assert np.allclose(performance, performance_in)
 
     # Check if we get the correct subset, if we reduce the parameter range:
-    X, y, noise, iteration = initialize_data(
+    X, y, noise, iteration, _, _ = initialize_data(
         parameter_ranges=[(0.0, 0.5)], data_path=testfile, resume=True,
     )
     assert iteration == 2

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -356,7 +356,7 @@ def local(  # noqa: C901
     if data_path is None:
         data_path = "data.npz"
     try:
-        X, y, noise, iteration = initialize_data(
+        X, y, noise, iteration, optima, performance = initialize_data(
             parameter_ranges=list(param_ranges.values()),
             resume=resume,
             data_path=data_path,
@@ -410,12 +410,17 @@ def local(  # noqa: C901
             result_object = create_result(Xi=X, yi=y, space=opt.space, models=[opt.gp])
             result_every_n = settings.get("result_every", result_every)
             if result_every_n > 0 and iteration % result_every_n == 0:
-                print_results(
-                    optimizer=opt,
-                    result_object=result_object,
-                    parameter_names=list(param_ranges.keys()),
-                    confidence=settings.get("confidence", confidence),
-                )
+                try:
+                    current_optimum, estimated_elo, estimated_std = print_results(
+                        optimizer=opt,
+                        result_object=result_object,
+                        parameter_names=list(param_ranges.keys()),
+                        confidence=settings.get("confidence", confidence),
+                    )
+                    optima.append(current_optimum)
+                    performance.append([iteration, estimated_elo, estimated_std])
+                except ValueError:
+                    pass
             plot_every_n = settings.get("plot_every", plot_every)
             if plot_every_n > 0 and iteration % plot_every_n == 0:
                 plot_results(
@@ -484,7 +489,14 @@ def local(  # noqa: C901
         iteration = len(X)
 
         with AtomicWriter(data_path, mode="wb", overwrite=True).open() as f:
-            np.savez_compressed(f, np.array(X), np.array(y), np.array(noise))
+            np.savez_compressed(
+                f,
+                np.array(X),
+                np.array(y),
+                np.array(noise),
+                np.array(optima),
+                np.array(performance),
+            )
         with AtomicWriter(model_path, mode="wb", overwrite=True).open() as f:
             dill.dump(opt, f)
 


### PR DESCRIPTION
This pull request lets chess-tuning-tools write the history of optima and their predicted Elo performance (with standard deviation) to disk. This is in preparation for #172 which requires this data.
The change is backwards compatible in that old data files are readable, but it will not be possible for older versions (<0.9) of chess-tuning-tools to be able to read the new data files.

Closes #171