### PR TITLE
Allow the user to pass points manually

### DIFF
--- a/docs/faq.myst
+++ b/docs/faq.myst
@@ -105,6 +105,31 @@ It is possible, but it will bias the estimated Elo values to slightly more
 extreme ones. This could lead the model to temporarily over-/underevalute
 certain regions until enough new data points were collected.
 
+### How can I pass my own points to the tuner to evaluate?
+```{note}
+:class: margin
+The parameter values have to be within the bounds specified in the config file.
+```
+Starting with 0.9.2, you can pass your own points to the tuner to evaluate.
+To do this, you need to create a .csv file using the ``--evaluate-points``
+option (``-p`` for short).
+Each row in the file should contain the parameters
+in the same order as specified in the config file of the tune.
+It is also possible to add an additional integer column to the file, which
+will indicate the number of rounds to run each point for.
+
+Here is an example of how a .csv file for a three parameter tune could look
+like:
+
+    0.3,125,0.0,25
+    0.4,1000,0.5,50
+    0.5,1000,0.0,50
+
+The first point would be evaluated using 25 rounds (50 games), while the
+second and third point would be evaluated using 50 rounds (100 games).
+
+
+
 ## Problems while tuning
 
 ### The computational overhead of the tuner has become too high? What can I do?

--- a/docs/parameters.myst
+++ b/docs/parameters.myst
@@ -219,6 +219,14 @@ fitting process:
   - The number of random points to consider as possible next point. Less points
     reduce the computation time per iteration, but reduce the coverage of the
     space. [default: 500]
+* -
+  - `-p --evaluate-points CSVFILE`
+  - Evaluate the given points first, before continuing with the points selected
+    by the tuner. The points are given as the rows of a CSV file with the
+    following format:
+    `x1,x2,...,xn[,samplesize]`. The first row should *not* be a header.
+    The last column is optional and contains the number of rounds to run each
+    point for. If not given, the default is whatever `"rounds"` is set to..
 ```
 
 ## Match-related parameters


### PR DESCRIPTION
A long requested and very useful feature is the possibility to add points manually for the tuner to evaluate.
This can be used for various use cases:

- Evaluate the default parameters of the engine to make sure the tuner knows about it.
- Supply the tuner with your own (maybe optimized) set of initialization points.
- Force the tuner to evaluate a region which could be interesting for some reason.
- Force the tuner to evaluate bad points, which could improve the overall model fit.
- Let the tuner test the current global optimum with a larger number of rounds to verify it.

This pull request implements that feature and adds the flag `--evaluate-points` (or `-p` for short).
For example, in case of a three parameter tune, the user could specify a .csv-file as follows

    0.3,125,0.0,25
    0.4,1000,0.5,50
    0.5,1000,0.0,50

This would let the tuner evaluate these three points. Note, how there is an (optional) fourth column, which indicates the number of rounds the tuner should use for each point. That way, it would for example be possible to let the tuner evaluate the current default parameters of the engine with a large number of rounds to bias it towards that region.

Closes #91 