### PR TITLE
Migrate formatting and lint tooling to Ruff

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-profile=black
-src_paths=tune,tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,18 @@
 repos:
   - repo: local
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
+      - id: ruff-format
+        name: ruff format
+        entry: ruff
+        language: python
+        additional_dependencies: ["ruff==0.14.2"]
         types: [python]
-        require_serial: true
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
+        args: ["format"]
+      - id: ruff-check
+        name: ruff check
+        entry: ruff
+        language: python
+        additional_dependencies: ["ruff==0.14.2"]
         types: [python]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
+        args: ["check"]
         require_serial: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Coding Style & Naming Conventions
 - Follow the existing code patterns: 4-space indentation, snake_case for variables and functions, PascalCase for classes.
-- Run `black`, `isort`, and `flake8` via `uv run --group dev nox -s pre-commit` or the individual tools before committing.
+- Run `ruff format` and `ruff check` via `uv run --group dev nox -s pre-commit` or the individual tools before committing.
 - Keep log messages short; prefer structured logging (e.g., `logger.info("Testing %s", value)`).
 
 ## Testing Guidelines

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,10 +77,11 @@ Ready to contribute? Here's how to set up `chess-tuning-tools` for local develop
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
+5. When you're done making changes, check that your changes pass Ruff and the
    tests, including testing other Python versions with nox::
 
-       $ uv run --group dev flake8 chess-tuning-tools tests
+       $ uv run --group dev ruff format tune tests
+       $ uv run --group dev ruff check tune tests
        $ uv run --group dev pytest
        $ uv run --group dev nox
 

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 tune tests
+lint: ## check style with ruff
+	ruff check tune tests
 
 test: ## run tests quickly with the default Python
 	pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,9 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "tune", "Chess Tuning Tools Documentation", [author], 1)]
+man_pages = [
+    (master_doc, "tune", "Chess Tuning Tools Documentation", [author], 1)
+]
 
 
 # -- Options for Texinfo output ----------------------------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,12 +1,11 @@
 """Nox sessions."""
 
+import nox
+from nox_uv import session
 from pathlib import Path
 from textwrap import dedent
 
-import nox
-from nox_uv import session
-
-locations = "tune", "noxfile.py"
+locations = ("tune", "tests", "noxfile.py")
 nox.options.sessions = ("pre-commit", "tests")
 python_versions = ["3.10", "3.11", "3.12", "3.13"]
 
@@ -37,7 +36,9 @@ def activate_virtualenv_in_precommit_hooks(session):
         text = hook.read_text()
         bindir = repr(session.bin)[1:-1]  # strip quotes
         if not (
-            Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text
+            Path("A") == Path("a")
+            and bindir.lower() in text.lower()
+            or bindir in text
         ):
             continue
 
@@ -68,11 +69,12 @@ def tests(session):
 
 
 @session(python="3.13", venv_backend="uv")
-def black(session):
-    """Run black code formatter."""
+def ruff(session):
+    """Run Ruff formatter and linter."""
     args = session.posargs or locations
-    session.install("black")
-    session.run("black", *args)
+    session.install("ruff==0.14.2")
+    session.run("ruff", "format", *args)
+    session.run("ruff", "check", *args)
 
 
 @session(name="pre-commit", python="3.13", venv_backend="uv")
@@ -80,10 +82,8 @@ def precommit(session):
     args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
     session.install(
         "pre-commit",
-        "black",
+        "ruff==0.14.2",
         "click",
-        "flake8",
-        "isort",
     )
     session.run("pre-commit", *args)
     if args and args[0] == "install":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,13 @@ tune = "tune.cli:cli"
 
 [dependency-groups]
 dev = [
-    "black>=22,<23",
-    "flake8-bugbear>=20.1.4",
-    "flake8>=3.8.3",
-    "isort>=5.3.2,<6",
     "mypy>=0.910",
     "nox-uv>=0.6.0",
     "nox>=2023.4.22",
     "pip>=21.1.2",
     "pre-commit>=2.6.0",
     "pytest>=6.0.1",
+    "ruff==0.14.2",
     "sphinx-autobuild>=0.7.1",
     "Sphinx>=3",
     "wheel>=0.34.2",
@@ -71,6 +68,22 @@ include = ["tune"]
 
 [tool.hatch.build.targets.wheel]
 include = ["tune"]
+
+[tool.ruff]
+exclude = ["docs"]
+line-length = 80
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "B", "C4"]
+ignore = ["E203", "E501", "F403", "F405"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 18
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 [build-system]
 requires = ["hatchling>=1.15"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,2 @@
-[flake8]
-ignore = E501, W503, F403, E203, F405
-exclude = docs
-max-line-length = 80
-max-complexity = 18
-application-import-names = tune
-select = B,C,E,F,W,T4,B9
-
 [aliases]
 test = pytest

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -28,7 +28,9 @@ def test_penta():
 
 def test_ldw_probabilities():
     result = ldw_probabilities(elo=50, draw_elo=200, bias=200)
-    expected = np.array([0.06975828735890623, 0.35877859523271227, 0.5714631174083815])
+    expected = np.array(
+        [0.06975828735890623, 0.35877859523271227, 0.5714631174083815]
+    )
     assert_almost_equal(result, expected)
 
 
@@ -40,7 +42,9 @@ def test_draw_rate_to_elo():
 
 def test_compute_probabilities_for_bias():
     result = compute_probabilities_for_bias(elo=50, draw_elo=200, bias=200)
-    expected = np.array([0.029894, 0.18540627, 0.41591514, 0.30154527, 0.06723932])
+    expected = np.array(
+        [0.029894, 0.18540627, 0.41591514, 0.30154527, 0.06723932]
+    )
     assert_almost_equal(result, expected)
 
 
@@ -66,7 +70,9 @@ def test_elo_to_bayeselo():
 
 def test_penta_to_score():
     counts = np.array([1, 2, 3, 4, 5])
-    result = penta_to_score(draw_rate=0.5, counts=counts, prior_games=10, prior_elo=0)
+    result = penta_to_score(
+        draw_rate=0.5, counts=counts, prior_games=10, prior_elo=0
+    )
     expected = 0.4016368226279837
     assert_almost_equal(result, expected)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,13 +6,18 @@ from tune.io import combine_nested_parameters, load_tuning_config
 def test_load_tuning_config():
     testdict = {
         "engines": [
-            {"command": "lc0", "fixed_parameters": {"CPuctBase": 13232, "Threads": 2}},
+            {
+                "command": "lc0",
+                "fixed_parameters": {"CPuctBase": 13232, "Threads": 2},
+            },
             {"command": "sf", "fixed_parameters": {"Threads": 8}},
         ],
         "parameter_ranges": {"CPuct": "Real(0.0, 1.0)"},
         "gp_samples": 100,
     }
-    json_dict, commands, fixed_params, param_ranges = load_tuning_config(testdict)
+    json_dict, commands, fixed_params, param_ranges = load_tuning_config(
+        testdict
+    )
     assert len(json_dict) == 1
     assert "gp_samples" in json_dict
     assert len(commands) == 2
@@ -42,7 +47,10 @@ def test_combine_nested_parameters():
     result = combine_nested_parameters(testdict)
     assert len(result) == 2
     assert "UCIParameter2" in result
-    assert result["UCIParameter2"] == "composite(sub-parameter1=0.0,sub-parameter2=1.0)"
+    assert (
+        result["UCIParameter2"]
+        == "composite(sub-parameter1=0.0,sub-parameter2=1.0)"
+    )
 
     # Test an incorrect specification of nested parameters:
     testdict = {

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -132,7 +132,9 @@ def test_reduce_ranges():
     x = ((0.0, "a"), (1.01, "a"), (0.5, "d"), (1.0, "c"))
     y = (0.0, 1.0, 2.0, 3.0)
     noise = (0.1, 0.2, 0.3, 0.4)
-    reduction_needed, x_new, y_new, noise_new = reduce_ranges(x, y, noise, space)
+    reduction_needed, x_new, y_new, noise_new = reduce_ranges(
+        x, y, noise, space
+    )
     assert reduction_needed
     assert tuple(x_new) == ((0.0, "a"), (1.0, "c"))
     assert tuple(y_new) == (0.0, 3.0)
@@ -307,7 +309,10 @@ def test_update_model():
             True,
         ),
         ("2018 >lc0(1): ucinewgame", True),
-        ("Finished game 1 (engine1 vs engine2): 0-1 {White loses on time}", False),
+        (
+            "Finished game 1 (engine1 vs engine2): 0-1 {White loses on time}",
+            False,
+        ),
         ("Finished game 3287 <engine1(0): ", False),
         ("...      White vs Black: 0 - 1 - 0  [0.000] 1", False),
     ],
@@ -317,7 +322,6 @@ def test_is_debug_log(log_line, expected):
 
 
 def test_check_log_for_errors(caplog):
-
     # Test loss on time:
     teststr = """Started game 1 of 2 (SFDev vs Lc0.11198)
     Finished game 1 (SFDev vs Lc0.11198): 1-0 {Black loses on time}
@@ -348,14 +352,16 @@ def test_check_log_for_errors(caplog):
     16995 >lc0(1): quit"""
     check_log_for_errors(teststr.split("\n"))
     assert (
-        "lc0's connection stalled as White. Game result is unreliable." in caplog.text
+        "lc0's connection stalled as White. Game result is unreliable."
+        in caplog.text
     )
 
     # Test correct forward of error:
     teststr = "797 <lc0(0): error The cuda backend requires a network file."
     check_log_for_errors([teststr])
     assert (
-        "cutechess-cli error: The cuda backend requires a network file." in caplog.text
+        "cutechess-cli error: The cuda backend requires a network file."
+        in caplog.text
     )
 
     # Test unknown UCI option:

--- a/tune/__init__.py
+++ b/tune/__init__.py
@@ -17,9 +17,19 @@ from tune.local import (
     reduce_ranges,
     run_match,
 )
-from tune.plots import partial_dependence, plot_objective, plot_optima, plot_performance
+from tune.plots import (
+    partial_dependence,
+    plot_objective,
+    plot_optima,
+    plot_performance,
+)
 from tune.priors import roundflat
-from tune.utils import TimeControl, TimeControlBag, expected_ucb, parse_timecontrol
+from tune.utils import (
+    TimeControl,
+    TimeControlBag,
+    expected_ucb,
+    parse_timecontrol,
+)
 
 __all__ = [
     "elo_to_prob",

--- a/tune/cli.py
+++ b/tune/cli.py
@@ -39,7 +39,9 @@ def cli():
 @click.option(
     "--verbose", "-v", is_flag=True, default=False, help="Turn on debug output."
 )
-@click.option("--logfile", default=None, help="Path to where the log is saved to.")
+@click.option(
+    "--logfile", default=None, help="Path to where the log is saved to."
+)
 @click.option(
     "--terminate-after", default=0, help="Terminate the client after x minutes."
 )
@@ -57,7 +59,9 @@ def cli():
     help="Skip calibrating the time control by running a benchmark.",
 )
 @click.option(
-    "--clientconfig", default=None, help="Path to the client configuration file."
+    "--clientconfig",
+    default=None,
+    help="Path to the client configuration file.",
 )
 @click.argument("dbconfig")
 def run_client(
@@ -96,7 +100,9 @@ def run_client(
 @click.option(
     "--verbose", "-v", is_flag=True, default=False, help="Turn on debug output."
 )
-@click.option("--logfile", default=None, help="Path to where the log is saved to.")
+@click.option(
+    "--logfile", default=None, help="Path to where the log is saved to."
+)
 @click.argument("command")
 @click.argument("experiment_file")
 @click.argument("dbconfig")
@@ -320,7 +326,9 @@ def run_server(verbose, logfile, command, experiment_file, dbconfig):
     type=click.Path(exists=False),
     show_default=True,
 )
-@click.option("--verbose", "-v", count=True, default=0, help="Turn on debug output.")
+@click.option(
+    "--verbose", "-v", count=True, default=0, help="Turn on debug output."
+)
 @click.option(
     "--warp-inputs/--no-warp-inputs",
     default=True,
@@ -362,7 +370,9 @@ def local(  # noqa: C901
     """
 
     json_dict = json.load(tuning_config)
-    settings, commands, fixed_params, param_ranges = load_tuning_config(json_dict)
+    settings, commands, fixed_params, param_ranges = load_tuning_config(
+        json_dict
+    )
     root_logger = setup_logger(
         verbose=verbose, logfile=settings.get("logfile", logfile)
     )
@@ -391,7 +401,9 @@ def local(  # noqa: C901
     # data/optimizer:
     gp_priors = create_priors(
         n_parameters=len(param_ranges),
-        signal_scale=settings.get("gp_signal_prior_scale", gp_signal_prior_scale),
+        signal_scale=settings.get(
+            "gp_signal_prior_scale", gp_signal_prior_scale
+        ),
         lengthscale_lower_bound=settings.get(
             "gp_lengthscale_prior_lb", gp_lengthscale_prior_lb
         ),
@@ -410,12 +422,16 @@ def local(  # noqa: C901
         n_points=settings.get("n_points", n_points),
         n_initial_points=settings.get("n_initial_points", n_initial_points),
         acq_function=settings.get("acq_function", acq_function),
-        acq_function_samples=settings.get("acq_function_samples", acq_function_samples),
+        acq_function_samples=settings.get(
+            "acq_function_samples", acq_function_samples
+        ),
         resume=resume,
         fast_resume=fast_resume,
         model_path=model_path,
         gp_initial_burnin=settings.get("gp_initial_burnin", gp_initial_burnin),
-        gp_initial_samples=settings.get("gp_initial_samples", gp_initial_samples),
+        gp_initial_samples=settings.get(
+            "gp_initial_samples", gp_initial_samples
+        ),
         gp_priors=gp_priors,
     )
     extra_points = load_points_to_evaluate(
@@ -433,18 +449,24 @@ def local(  # noqa: C901
 
         # If a model has been fit, print/plot results so far:
         if len(y) > 0 and opt.gp.chain_ is not None:
-            result_object = create_result(Xi=X, yi=y, space=opt.space, models=[opt.gp])
+            result_object = create_result(
+                Xi=X, yi=y, space=opt.space, models=[opt.gp]
+            )
             result_every_n = settings.get("result_every", result_every)
             if result_every_n > 0 and iteration % result_every_n == 0:
                 try:
-                    current_optimum, estimated_elo, estimated_std = print_results(
-                        optimizer=opt,
-                        result_object=result_object,
-                        parameter_names=list(param_ranges.keys()),
-                        confidence=settings.get("confidence", confidence),
+                    current_optimum, estimated_elo, estimated_std = (
+                        print_results(
+                            optimizer=opt,
+                            result_object=result_object,
+                            parameter_names=list(param_ranges.keys()),
+                            confidence=settings.get("confidence", confidence),
+                        )
                     )
                     optima.append(current_optimum)
-                    performance.append((int(iteration), estimated_elo, estimated_std))
+                    performance.append(
+                        (int(iteration), estimated_elo, estimated_std)
+                    )
                 except ValueError:
                     pass
             plot_every_n = settings.get("plot_every", plot_every)
@@ -468,7 +490,9 @@ def local(  # noqa: C901
             # Log that we are evaluating the extra point:
             point_display = dict(zip(param_ranges.keys(), point, strict=True))
             root_logger.info(
-                "Evaluating extra point %s for %s rounds.", point_display, n_rounds
+                "Evaluating extra point %s for %s rounds.",
+                point_display,
+                n_rounds,
             )
             used_extra_point = True
         else:
@@ -481,7 +505,9 @@ def local(  # noqa: C901
         root_logger.info("Testing %s", point_dict)
 
         # Prepare engines.json file for cutechess-cli:
-        engine_json = prepare_engines_json(commands=commands, fixed_params=fixed_params)
+        engine_json = prepare_engines_json(
+            commands=commands, fixed_params=fixed_params
+        )
         root_logger.debug(f"engines.json is prepared:\n{engine_json}")
         write_engines_json(engine_json, point_dict)
 
@@ -505,9 +531,13 @@ def local(  # noqa: C901
         root_logger.info(f"Experiment finished ({difference}s elapsed).")
 
         # Parse cutechess-cli output and report results (Elo and standard deviation):
-        score, error_variance, draw_rate = parse_experiment_result(out_exp, **settings)
+        score, error_variance, draw_rate = parse_experiment_result(
+            out_exp, **settings
+        )
         root_logger.info(
-            "Got Elo: {} +- {}".format(-score * 100, np.sqrt(error_variance) * 100)
+            "Got Elo: {} +- {}".format(
+                -score * 100, np.sqrt(error_variance) * 100
+            )
         )
         root_logger.info("Estimated draw rate: {:.2%}".format(draw_rate))
 
@@ -523,8 +553,12 @@ def local(  # noqa: C901
             ),
             gp_burnin=settings.get("gp_burnin", gp_burnin),
             gp_samples=settings.get("gp_samples", gp_samples),
-            gp_initial_burnin=settings.get("gp_initial_burnin", gp_initial_burnin),
-            gp_initial_samples=settings.get("gp_initial_samples", gp_initial_samples),
+            gp_initial_burnin=settings.get(
+                "gp_initial_burnin", gp_initial_burnin
+            ),
+            gp_initial_samples=settings.get(
+                "gp_initial_samples", gp_initial_samples
+            ),
         )
         # If we used an extra point, we need to reset n_initial_points of the optimizer:
         if used_extra_point:

--- a/tune/db_workers/dbmodels/__init__.py
+++ b/tune/db_workers/dbmodels/__init__.py
@@ -1,4 +1,11 @@
 from tune.db_workers.dbmodels.base_model import Base
 from tune.db_workers.dbmodels.models import *
 
-__all__ = ["Base", "SqlTune", "SqlJob", "SqlUCIParam", "SqlTimeControl", "SqlResult"]
+__all__ = [
+    "Base",
+    "SqlTune",
+    "SqlJob",
+    "SqlUCIParam",
+    "SqlTimeControl",
+    "SqlResult",
+]

--- a/tune/db_workers/dbmodels/models.py
+++ b/tune/db_workers/dbmodels/models.py
@@ -69,7 +69,9 @@ try:
 
         tune_id = Column(Integer, ForeignKey(f"{SCHEMA}.tunes.id"))
         tune = relationship("SqlTune", back_populates="jobs")
-        params = relationship("SqlUCIParam", back_populates="job", cascade="all")
+        params = relationship(
+            "SqlUCIParam", back_populates="job", cascade="all"
+        )
         time_controls = relationship("SqlTimeControl", secondary=job_tc_table)
         results = relationship("SqlResult", back_populates="job")
 
@@ -107,10 +109,14 @@ try:
 
         def __repr__(self):
             engine1_inc = (
-                "" if self.engine1_increment is None else f"+{self.engine1_increment}"
+                ""
+                if self.engine1_increment is None
+                else f"+{self.engine1_increment}"
             )
             engine2_inc = (
-                "" if self.engine2_increment is None else f"+{self.engine2_increment}"
+                ""
+                if self.engine2_increment is None
+                else f"+{self.engine2_increment}"
             )
             return (
                 f"<TC (id={self.id}, engine1={self.engine1_time}{engine1_inc},"
@@ -129,7 +135,9 @@ try:
     class SqlResult(Base):
         __tablename__ = "results"
         __table_args__ = ({"schema": SCHEMA},)
-        job_id = Column(Integer, ForeignKey(f"{SCHEMA}.jobs.id"), primary_key=True)
+        job_id = Column(
+            Integer, ForeignKey(f"{SCHEMA}.jobs.id"), primary_key=True
+        )
         tc_id = Column(
             Integer, ForeignKey(f"{SCHEMA}.timecontrols.id"), primary_key=True
         )

--- a/tune/db_workers/tuning_client.py
+++ b/tune/db_workers/tuning_client.py
@@ -55,7 +55,9 @@ class TuningClient(object):
                 self.logger.debug(f"Reading DB config:\n{config}")
                 self.connect_params = json.loads(config)
         else:
-            raise ValueError(f"No config file found at provided path:\n{dbconfig_path}")
+            raise ValueError(
+                f"No config file found at provided path:\n{dbconfig_path}"
+            )
 
         self.engine = create_sqlalchemy_engine(self.connect_params)
         Base.metadata.create_all(self.engine)
@@ -131,7 +133,9 @@ class TuningClient(object):
         err_string = results.stderr.decode("utf-8")
         error_occured = False
         if re.search("connection stalls", string):
-            self.logger.error("Connection stalled during match. Aborting client.")
+            self.logger.error(
+                "Connection stalled during match. Aborting client."
+            )
             error_occured = True
         elif re.search("Terminating process", string):
             self.logger.error("Engine was terminated. Aborting client.")
@@ -142,9 +146,11 @@ class TuningClient(object):
             sys.exit(1)
         self.logger.debug(f"Cutechess result string:\n{string}")
         self.logger.debug(f"Cutechess error string:\n{err_string}")
-        result = re.findall(r"Score of.*:\s*([0-9]+\s-\s[0-9]+\s-\s[0-9]+)", string)[-1]
-        w, l, d = [float(x) for x in re.findall("[0-9]", result)]
-        return MatchResult(wins=w, losses=l, draws=d)
+        result = re.findall(
+            r"Score of.*:\s*([0-9]+\s-\s[0-9]+\s-\s[0-9]+)", string
+        )[-1]
+        wins, losses, draws = [float(x) for x in re.findall("[0-9]", result)]
+        return MatchResult(wins=wins, losses=losses, draws=draws)
 
     def run_benchmark(self, config):
         def uci_to_cl(k, v):
@@ -294,7 +300,9 @@ class TuningClient(object):
     def run(self):
         while True:
             if self.interrupt_pressed:
-                self.logger.info("Shutting down after receiving shutdown signal.")
+                self.logger.info(
+                    "Shutting down after receiving shutdown signal."
+                )
                 sys.exit(0)
             if self.end_time is not None and self.end_time < time():
                 self.logger.info("Shutdown timer triggered. Closing")
@@ -304,7 +312,8 @@ class TuningClient(object):
                 rows = (
                     session.query(SqlJob, SqlResult)
                     .filter(
-                        SqlJob.id == SqlResult.job_id, SqlJob.active == True  # noqa
+                        SqlJob.id == SqlResult.job_id,
+                        SqlJob.active == True,  # noqa
                     )
                     .all()
                 )
@@ -316,7 +325,9 @@ class TuningClient(object):
                     continue
 
                 applicable_jobs = [
-                    row for row in rows if row[0].minimum_version <= CLIENT_VERSION
+                    row
+                    for row in rows
+                    if row[0].minimum_version <= CLIENT_VERSION
                 ]
                 if len(applicable_jobs) < len(rows):
                     self.logger.warning(
@@ -369,9 +380,12 @@ class TuningClient(object):
                     )
 
                 # 3. Run experiment (and block)
-                self.logger.info(f"Running match with time control\n{time_control}")
+                self.logger.info(
+                    f"Running match with time control\n{time_control}"
+                )
                 result = self.run_experiment(
-                    time_control=time_control, cutechess_options=config["cutechess"]
+                    time_control=time_control,
+                    cutechess_options=config["cutechess"],
                 )
                 self.logger.info(
                     f"Match result (WLD): {result.wins} - {result.losses} - "

--- a/tune/db_workers/utils.py
+++ b/tune/db_workers/utils.py
@@ -109,9 +109,9 @@ def compute_probabilities(elo, draw_elo, biases):
 
 def elo_to_bayeselo(elo, draw_elo, biases):
     def func(bayeselo):
-        return score_in_01(compute_probabilities(bayeselo, draw_elo, biases)) - expit(
-            ELO_CONSTANT * elo
-        )
+        return score_in_01(
+            compute_probabilities(bayeselo, draw_elo, biases)
+        ) - expit(ELO_CONSTANT * elo)
 
     return root_scalar(func, method="brentq", bracket=(-1000, 1000)).root
 

--- a/tune/io.py
+++ b/tune/io.py
@@ -22,7 +22,9 @@ __all__ = [
 # TODO: Backup file to restore it, should there be an error
 def uci_tuple(uci_string):
     try:
-        name, value = re.findall(r"name\s+(\S.*?)\s+value\s+(.*?)\s*$", uci_string)[0]
+        name, value = re.findall(
+            r"name\s+(\S.*?)\s+value\s+(.*?)\s*$", uci_string
+        )[0]
     except IndexError:
         print(f"Error parsing UCI tuples:\n{uci_string}")
         sys.exit(1)
@@ -120,7 +122,7 @@ def parse_ranges(s):
         # First check, if the string is a list/tuple or a function call:
         param_str = re.findall(r"(\w+)\(", s)
         if len(param_str) > 0:  # Function
-            args, kwargs = [], dict()
+            args, kwargs = [], {}
             # TODO: this split does not always work
             #  (example Categorical(["a", "b", "c"]))
             prior_param_strings = re.findall(r"\((.*?)\)", s)[0].split(",")
@@ -140,7 +142,9 @@ def parse_ranges(s):
             if hasattr(skspace, param_str[0]):
                 dim = getattr(skspace, param_str[0])(*args, **kwargs)
             else:
-                raise ValueError("Dimension {} does not exist.".format(param_str))
+                raise ValueError(
+                    "Dimension {} does not exist.".format(param_str)
+                )
             dimensions.append(dim)
         else:  # Tuple or list
             # We assume that the contents of the collection should be used as is and
@@ -186,15 +190,19 @@ def load_tuning_config(json_dict):
     engines = json_dict["engines"]
     for e in engines:
         if "command" not in e:
-            raise ValueError("Tuning config contains an engine without command.")
+            raise ValueError(
+                "Tuning config contains an engine without command."
+            )
         commands.append(e["command"])
         if "fixed_parameters" not in e:
-            fixed_params.append(dict())
+            fixed_params.append({})
         else:
             fixed_params.append(e["fixed_parameters"])
     del json_dict["engines"]
     if "parameter_ranges" not in json_dict:
-        raise ValueError("There are no parameter ranges defined in the config file.")
+        raise ValueError(
+            "There are no parameter ranges defined in the config file."
+        )
     param_ranges = parse_ranges(json_dict["parameter_ranges"])
     del json_dict["parameter_ranges"]
     # All remaining settings will be returned as is:
@@ -245,8 +253,8 @@ def combine_nested_parameters(d: dict) -> dict:
     {'UCIParameter1': 'composite(sub-parameter1=0.0,sub-parameter2=1.0)'}
     """
     re_pattern = r"(\S+|\S.*\S)=(.+)\((.+)\)"
-    result = dict()
-    nested_params = dict()
+    result = {}
+    nested_params = {}
     for k, v in d.items():
         match = re.search(pattern=re_pattern, string=k)
         if match is None:
@@ -254,7 +262,7 @@ def combine_nested_parameters(d: dict) -> dict:
         else:
             name, value, sub_param = match.groups()
             if name not in nested_params:
-                nested_params[name] = (value, dict())
+                nested_params[name] = (value, {})
             else:
                 existing_value = nested_params[name][0]
                 if existing_value != value:

--- a/tune/plots.py
+++ b/tune/plots.py
@@ -56,7 +56,14 @@ def _evenly_sample(dim, n_points):
 
 
 def partial_dependence(
-    space, model, i, j=None, sample_points=None, n_samples=250, n_points=40, x_eval=None
+    space,
+    model,
+    i,
+    j=None,
+    sample_points=None,
+    n_samples=250,
+    n_points=40,
+    x_eval=None,
 ):
     """Calculate the partial dependence for dimensions `i` and `j` with
     respect to the objective value, as approximated by `model`.
@@ -213,8 +220,14 @@ def plot_objective_1d(
 
     if fig is None:
         plt.style.use("dark_background")
-        gs_kw = dict(width_ratios=(1,), height_ratios=[5, 1], hspace=0.05)
-        fig, ax = plt.subplots(figsize=figsize, nrows=2, gridspec_kw=gs_kw, sharex=True)
+        gs_kw = {
+            "width_ratios": (1,),
+            "height_ratios": [5, 1],
+            "hspace": 0.05,
+        }
+        fig, ax = plt.subplots(
+            figsize=figsize, nrows=2, gridspec_kw=gs_kw, sharex=True
+        )
         for a in ax:
             a.set_facecolor("#36393f")
         fig.patch.set_facecolor("#36393f")
@@ -228,7 +241,9 @@ def plot_objective_1d(
                 min_x = expected_ucb(
                     result, alpha=0.0, n_random_starts=n_random_restarts
                 )[0]
-                min_ucb = expected_ucb(result, n_random_starts=n_random_restarts)[0]
+                min_ucb = expected_ucb(
+                    result, n_random_starts=n_random_restarts
+                )[0]
         except ValueError:
             failures += 1
             if failures == 10:
@@ -274,7 +289,13 @@ def plot_objective_1d(
     ax[1].set_ylabel("Elo")
     fig.legend(
         (mean_plot, err_plot, opt_plot, pess_plot, match_plot),
-        ("Mean", f"{confidence:.0%} CI", "Optimum", "Conservative Optimum", "Matches"),
+        (
+            "Mean",
+            f"{confidence:.0%} CI",
+            "Optimum",
+            "Conservative Optimum",
+            "Matches",
+        ),
         loc="lower center",
         ncol=5,
         bbox_to_anchor=(0.5, -0.03),
@@ -361,7 +382,7 @@ def plot_objective(
         locator = None
     else:
         raise ValueError(
-            "Valid values for zscale are 'linear' and 'log'," " not '%s'." % zscale
+            "Valid values for zscale are 'linear' and 'log', not '%s'." % zscale
         )
     if fig is None:
         fig, ax = plt.subplots(
@@ -386,7 +407,9 @@ def plot_objective(
                 min_x = expected_ucb(
                     result, alpha=0.0, n_random_starts=n_random_restarts
                 )[0]
-                min_ucb = expected_ucb(result, n_random_starts=n_random_restarts)[0]
+                min_ucb = expected_ucb(
+                    result, n_random_starts=n_random_restarts
+                )[0]
         except ValueError:
             failures += 1
             if failures == 10:
@@ -409,8 +432,12 @@ def plot_objective(
                 yi_min, yi_max = np.min(yi), np.max(yi)
                 ax[i, i].plot(xi, yi, color=colors[1])
                 if failures != 10:
-                    ax[i, i].axvline(min_x[i], linestyle="--", color=colors[3], lw=1)
-                    ax[i, i].axvline(min_ucb[i], linestyle="--", color=colors[5], lw=1)
+                    ax[i, i].axvline(
+                        min_x[i], linestyle="--", color=colors[3], lw=1
+                    )
+                    ax[i, i].axvline(
+                        min_ucb[i], linestyle="--", color=colors[5], lw=1
+                    )
                     ax[i, i].text(
                         min_x[i],
                         yi_min + 0.9 * (yi_max - yi_min),
@@ -429,9 +456,16 @@ def plot_objective(
                 xi, yi, zi = partial_dependence(
                     space, result.models[-1], i, j, rvs_transformed, n_points
                 )
-                ax[i, j].contourf(xi, yi, zi, levels, locator=locator, cmap="viridis_r")
+                ax[i, j].contourf(
+                    xi, yi, zi, levels, locator=locator, cmap="viridis_r"
+                )
                 ax[i, j].scatter(
-                    samples[:, j], samples[:, i], c="k", s=10, lw=0.0, alpha=alpha
+                    samples[:, j],
+                    samples[:, i],
+                    c="k",
+                    s=10,
+                    lw=0.0,
+                    alpha=alpha,
                 )
                 if failures != 10:
                     ax[i, j].scatter(min_x[j], min_x[i], c=["r"], s=20, lw=0.0)
@@ -618,12 +652,12 @@ def plot_optima(
             x=transformed_point[0] + 0.01,
             y=transformed_point[1] - 0.02,
             s=s,
-            bbox=dict(
-                facecolor="#36393f",
-                edgecolor="None",
-                alpha=0.5,
-                boxstyle="square,pad=0.1",
-            ),
+            bbox={
+                "facecolor": "#36393f",
+                "edgecolor": "None",
+                "alpha": 0.5,
+                "boxstyle": "square,pad=0.1",
+            },
             transform=a.transAxes,
             horizontalalignment="left",
             verticalalignment="top",
@@ -739,7 +773,9 @@ def plot_performance(
         linewidth=1,
         alpha=0.3,
     )
-    ax.legend(loc="upper center", frameon=False, bbox_to_anchor=(0.5, -0.08), ncol=3)
+    ax.legend(
+        loc="upper center", frameon=False, bbox_to_anchor=(0.5, -0.08), ncol=3
+    )
     ax.set_xlabel("Iteration")
     ax.set_ylabel("Elo")
     ax.set_xlim(min(iterations), max(iterations))

--- a/tune/priors.py
+++ b/tune/priors.py
@@ -62,7 +62,7 @@ def make_invgamma_prior(
         raise ValueError("The bounds cannot be equal to or smaller than 0.")
     if lower_bound >= upper_bound:
         raise ValueError(
-            "Lower bound needs to be strictly smaller than the upper " "bound."
+            "Lower bound needs to be strictly smaller than the upper bound."
         )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -122,7 +122,11 @@ def create_priors(
     )
     noise_prior = halfnorm(scale=noise_scale)
 
-    priors = [lambda x: signal_prior.logpdf(np.sqrt(np.exp(x))) + x / 2.0 - np.log(2.0)]
+    priors = [
+        lambda x: signal_prior.logpdf(np.sqrt(np.exp(x)))
+        + x / 2.0
+        - np.log(2.0)
+    ]
     for _ in range(n_parameters):
         priors.append(lambda x: lengthscale_prior.logpdf(np.exp(x)) + x)
     priors.append(

--- a/tune/summary.py
+++ b/tune/summary.py
@@ -32,7 +32,9 @@ def _round_all_intervals(intervals, threshold=0.01, max_precision=32):
                 )
         else:
             sub_result.append(
-                _round_interval(dim, threshold=threshold, max_precision=max_precision)
+                _round_interval(
+                    dim, threshold=threshold, max_precision=max_precision
+                )
             )
         result.append(sub_result)
     return result
@@ -52,7 +54,8 @@ def confidence_intervals(
 ):
     if param_names is None:
         param_names = [
-            "Parameter {}".format(i) for i in range(len(optimizer.space.dimensions))
+            "Parameter {}".format(i)
+            for i in range(len(optimizer.space.dimensions))
         ]
     intervals = optimizer.optimum_intervals(
         hdi_prob=hdi_prob,
@@ -70,7 +73,12 @@ def confidence_intervals(
     max_ub = max(max(len(str(row[1])) for sub in rounded for row in sub), 11)
     format_string = "{:<{}}  {:>{}}  {:>{}}\n"
     output = format_string.format(
-        "Parameter", max_param_length, "Lower bound", max_lb, "Upper bound", max_ub
+        "Parameter",
+        max_param_length,
+        "Lower bound",
+        max_lb,
+        "Upper bound",
+        max_ub,
     )
     output += "{:-^{}}\n".format("", max_param_length + max_lb + max_ub + 4)
     for sub, name in zip(rounded, param_names, strict=True):
@@ -80,6 +88,11 @@ def confidence_intervals(
             else:
                 name_out = ""
             output += format_string.format(
-                name_out, max_param_length, interval[0], max_lb, interval[1], max_ub
+                name_out,
+                max_param_length,
+                interval[0],
+                max_lb,
+                interval[1],
+                max_ub,
             )
     return output

--- a/tune/utils.py
+++ b/tune/utils.py
@@ -182,7 +182,9 @@ def latest_iterations(
         return (iterations, *arrays)
     else:
         # Compute the indices of the latest unique iterations:
-        indices = np.searchsorted(iterations, unique_iterations, side="right") - 1
+        indices = (
+            np.searchsorted(iterations, unique_iterations, side="right") - 1
+        )
         return (
             iterations[indices],
             *(a[indices] for a in arrays),

--- a/uv.lock
+++ b/uv.lock
@@ -148,26 +148,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/59/e873cc6807fb62c11131e5258ca15577a3b7452abad08dc49286cf8245e8/black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f", size = 553112, upload-time = "2022-12-09T15:57:04.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/d9/60852a6fc2f85374db20a9767dacfe50c2172eb8388f46018c8daf836995/black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d", size = 1556665, upload-time = "2022-12-09T16:04:10.897Z" },
-    { url = "https://files.pythonhosted.org/packages/71/57/975782465cc6b514f2c972421e29b933dfbb51d4a95948a4e0e94f36ea38/black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351", size = 1205632, upload-time = "2022-12-09T16:14:38.465Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e0/6aa02d14785c4039b38bfed6f9ee28a952b2d101c64fc97b15811fa8bd04/black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f", size = 1536577, upload-time = "2022-12-09T16:04:12.721Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/49/420dcfccba3215dc4e5790fa47572ef14129df1c5e95dd87b5ad30211b01/black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4", size = 1209873, upload-time = "2022-12-09T16:14:40.318Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf", size = 167343, upload-time = "2022-12-09T15:57:02.229Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
@@ -348,16 +328,13 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
-    { name = "flake8" },
-    { name = "flake8-bugbear" },
-    { name = "isort" },
     { name = "mypy" },
     { name = "nox" },
     { name = "nox-uv" },
     { name = "pip" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "wheel" },
@@ -385,16 +362,13 @@ provides-extras = ["dist", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=22,<23" },
-    { name = "flake8", specifier = ">=3.8.3" },
-    { name = "flake8-bugbear", specifier = ">=20.1.4" },
-    { name = "isort", specifier = ">=5.3.2,<6" },
     { name = "mypy", specifier = ">=0.910" },
     { name = "nox", specifier = ">=2023.4.22" },
     { name = "nox-uv", specifier = ">=0.6.0" },
     { name = "pip", specifier = ">=21.1.2" },
     { name = "pre-commit", specifier = ">=2.6.0" },
     { name = "pytest", specifier = ">=6.0.1" },
+    { name = "ruff", specifier = "==0.14.2" },
     { name = "sphinx", specifier = ">=3" },
     { name = "sphinx-autobuild", specifier = ">=0.7.1" },
     { name = "wheel", specifier = ">=0.34.2" },
@@ -641,33 +615,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
-name = "flake8-bugbear"
-version = "25.10.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "flake8" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/54/0f6e431adbc67fd420540e386cb20b57e73e8aeb393f0ae2311e91b4548f/flake8_bugbear-25.10.21.tar.gz", hash = "sha256:2876afcaed8bfb3464cf33e3ec42cc3bec0a004165b84400dc3392b0547c2714", size = 83080, upload-time = "2025-10-22T01:27:03.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/0e/8ba976f7d477cad69cc7af08dc7b0163181a5e19a82fe721f954e369c067/flake8_bugbear-25.10.21-py3-none-any.whl", hash = "sha256:f1c5654f9d9d3e62e90da1f0335551fdbc565c51749713177dbcfb9edb105405", size = 37257, upload-time = "2025-10-22T01:27:02.105Z" },
 ]
 
 [[package]]
@@ -920,15 +867,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d0/274fbf7b0b12643cbbc001ce13e6a5b1607ac4929d1b11c72460152c9fc3/ipython-8.37.0-py3-none-any.whl", hash = "sha256:ed87326596b878932dbcb171e3e698845434d8c61b8d8cd474bf663041a9dcf2", size = 831864, upload-time = "2025-05-31T16:39:06.38Z" },
-]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
 ]
 
 [[package]]
@@ -1265,15 +1203,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1802,15 +1731,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1836,15 +1756,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/ea/3ab478cccacc2e8ef69892c42c44ae547bae089f356c4b47caf61730958d/pydata_sphinx_theme-0.15.4.tar.gz", hash = "sha256:7762ec0ac59df3acecf49fd2f889e1b4565dbce8b88b2e29ee06fdd90645a06d", size = 2400673, upload-time = "2024-06-25T19:28:45.041Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/d3/c622950d87a2ffd1654208733b5bd1c5645930014abed8f4c0d74863988b/pydata_sphinx_theme-0.15.4-py3-none-any.whl", hash = "sha256:2136ad0e9500d0949f96167e63f3e298620040aea8f9c74621959eda5d4cf8e6", size = 4640157, upload-time = "2024-06-25T19:28:42.383Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -2133,6 +2044,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/f9/ce43dbe62767432273ed2584cef71fef8411bddfb64125d4c19128015018/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:6aa1bfce3f83baf00d9c5fcdbba93a3ab79958b4c7d7d1f55e7fe68c20e63912", size = 561530, upload-time = "2025-10-22T22:24:22.958Z" },
     { url = "https://files.pythonhosted.org/packages/46/c9/ffe77999ed8f81e30713dd38fd9ecaa161f28ec48bb80fa1cd9118399c27/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:7b0f9dceb221792b3ee6acb5438eb1f02b0cb2c247796a72b016dcc92c6de829", size = 585453, upload-time = "2025-10-22T22:24:24.779Z" },
     { url = "https://files.pythonhosted.org/packages/ed/d2/4a73b18821fd4669762c855fd1f4e80ceb66fb72d71162d14da58444a763/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5d0145edba8abd3db0ab22b5300c99dc152f5c9021fab861be0f0544dc3cbc5f", size = 552199, upload-time = "2025-10-22T22:24:26.54Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/34/8218a19b2055b80601e8fd201ec723c74c7fe1ca06d525a43ed07b6d8e85/ruff-0.14.2.tar.gz", hash = "sha256:98da787668f239313d9c902ca7c523fe11b8ec3f39345553a51b25abc4629c96", size = 5539663, upload-time = "2025-10-23T19:37:00.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/dd/23eb2db5ad9acae7c845700493b72d3ae214dce0b226f27df89216110f2b/ruff-0.14.2-py3-none-linux_armv6l.whl", hash = "sha256:7cbe4e593505bdec5884c2d0a4d791a90301bc23e49a6b1eb642dd85ef9c64f1", size = 12533390, upload-time = "2025-10-23T19:36:18.044Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/8c/5f9acff43ddcf3f85130d0146d0477e28ccecc495f9f684f8f7119b74c0d/ruff-0.14.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8d54b561729cee92f8d89c316ad7a3f9705533f5903b042399b6ae0ddfc62e11", size = 12887187, upload-time = "2025-10-23T19:36:22.664Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fa/047646491479074029665022e9f3dc6f0515797f40a4b6014ea8474c539d/ruff-0.14.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c8753dfa44ebb2cde10ce5b4d2ef55a41fb9d9b16732a2c5df64620dbda44a3", size = 11925177, upload-time = "2025-10-23T19:36:24.778Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8b/c44cf7fe6e59ab24a9d939493a11030b503bdc2a16622cede8b7b1df0114/ruff-0.14.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d0bbeffb8d9f4fccf7b5198d566d0bad99a9cb622f1fc3467af96cb8773c9e3", size = 12358285, upload-time = "2025-10-23T19:36:26.979Z" },
+    { url = "https://files.pythonhosted.org/packages/45/01/47701b26254267ef40369aea3acb62a7b23e921c27372d127e0f3af48092/ruff-0.14.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7047f0c5a713a401e43a88d36843d9c83a19c584e63d664474675620aaa634a8", size = 12303832, upload-time = "2025-10-23T19:36:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5c/ae7244ca4fbdf2bee9d6405dcd5bc6ae51ee1df66eb7a9884b77b8af856d/ruff-0.14.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bf8d2f9aa1602599217d82e8e0af7fd33e5878c4d98f37906b7c93f46f9a839", size = 13036995, upload-time = "2025-10-23T19:36:31.861Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4c/0860a79ce6fd4c709ac01173f76f929d53f59748d0dcdd662519835dae43/ruff-0.14.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1c505b389e19c57a317cf4b42db824e2fca96ffb3d86766c1c9f8b96d32048a7", size = 14512649, upload-time = "2025-10-23T19:36:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7f/d365de998069720a3abfc250ddd876fc4b81a403a766c74ff9bde15b5378/ruff-0.14.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a307fc45ebd887b3f26b36d9326bb70bf69b01561950cdcc6c0bdf7bb8e0f7cc", size = 14088182, upload-time = "2025-10-23T19:36:36.983Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ea/d8e3e6b209162000a7be1faa41b0a0c16a133010311edc3329753cc6596a/ruff-0.14.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61ae91a32c853172f832c2f40bd05fd69f491db7289fb85a9b941ebdd549781a", size = 13599516, upload-time = "2025-10-23T19:36:39.208Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ea/c7810322086db68989fb20a8d5221dd3b79e49e396b01badca07b433ab45/ruff-0.14.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1967e40286f63ee23c615e8e7e98098dedc7301568bd88991f6e544d8ae096", size = 13272690, upload-time = "2025-10-23T19:36:41.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/39/10b05acf8c45786ef501d454e00937e1b97964f846bf28883d1f9619928a/ruff-0.14.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2877f02119cdebf52a632d743a2e302dea422bfae152ebe2f193d3285a3a65df", size = 13496497, upload-time = "2025-10-23T19:36:43.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a1/1f25f8301e13751c30895092485fada29076e5e14264bdacc37202e85d24/ruff-0.14.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e681c5bc777de5af898decdcb6ba3321d0d466f4cb43c3e7cc2c3b4e7b843a05", size = 12266116, upload-time = "2025-10-23T19:36:45.625Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/0029bfc9ce16ae78164e6923ef392e5f173b793b26cc39aa1d8b366cf9dc/ruff-0.14.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e21be42d72e224736f0c992cdb9959a2fa53c7e943b97ef5d081e13170e3ffc5", size = 12281345, upload-time = "2025-10-23T19:36:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ab/ece7baa3c0f29b7683be868c024f0838770c16607bea6852e46b202f1ff6/ruff-0.14.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b8264016f6f209fac16262882dbebf3f8be1629777cf0f37e7aff071b3e9b92e", size = 12629296, upload-time = "2025-10-23T19:36:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7f/638f54b43f3d4e48c6a68062794e5b367ddac778051806b9e235dfb7aa81/ruff-0.14.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ca36b4cb4db3067a3b24444463ceea5565ea78b95fe9a07ca7cb7fd16948770", size = 13371610, upload-time = "2025-10-23T19:36:51.882Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/35/3654a973ebe5b32e1fd4a08ed2d46755af7267da7ac710d97420d7b8657d/ruff-0.14.2-py3-none-win32.whl", hash = "sha256:41775927d287685e08f48d8eb3f765625ab0b7042cc9377e20e64f4eb0056ee9", size = 12415318, upload-time = "2025-10-23T19:36:53.961Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/3758bcf9e0b6a4193a6f51abf84254aba00887dfa8c20aba18aa366c5f57/ruff-0.14.2-py3-none-win_amd64.whl", hash = "sha256:0df3424aa5c3c08b34ed8ce099df1021e3adaca6e90229273496b839e5a7e1af", size = 13565279, upload-time = "2025-10-23T19:36:56.578Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/aa883766f8ef9ffbe6aa24f7192fb71632f31a30e77eb39aa2b0dc4290ac/ruff-0.14.2-py3-none-win_arm64.whl", hash = "sha256:ea9d635e83ba21569fbacda7e78afbfeb94911c9434aff06192d9bc23fd5495a", size = 12554956, upload-time = "2025-10-23T19:36:58.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 - Replaced the Black/Flake8/iSort toolchain with Ruff everywhere (pyproject dev deps, Ruff config blocks, updated lockfile). Added a dedicated Ruff nox session and switched pre-commit hooks to managed Ruff installs so contributors get consistent behavior without manual tooling setup.
  - Updated docs and helper scripts so “ruff format/check” are the standard workflow, and removed leftover flake8/iSort configuration files.
  - Fixed the lint violations Ruff surfaced: renamed the ambiguous match-result variable, converted inline lambdas to named helpers, and
    modernized empty dict/list construction and kwargs; Ruff formatting applied across the project to keep it consistent.

  Validation

  - uv run --group dev ruff format .
  - uv run --group dev ruff check --fix .
  - uv run --group dev pytest